### PR TITLE
Add a h1b_tests app, which will be used to run unit and integration tests.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,6 +2,10 @@
 	path = third_party/libtock-c
 	url = https://github.com/tock/libtock-c
 
+[submodule "third_party/libtock-rs"]
+	path = third_party/libtock-rs
+	url = https://github.com/tock/libtock-rs
+
 [submodule "third_party/tock"]
 	path = third_party/tock
 	url = https://github.com/tock/tock.git

--- a/golf2/apps/.cargo/config
+++ b/golf2/apps/.cargo/config
@@ -1,0 +1,22 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[build]
+target = "thumbv7m-none-eabi"
+
+[target.thumbv7m-none-eabi]
+linker = "rust-lld"
+rustflags = ["-C", "link-arg=-T../../../third_party/libtock-rs/layout.ld",
+             "-C", "relocation-model=ropi-rwpi",
+             "-Z", "linker-flavor=ld.lld"]

--- a/golf2/apps/.gitignore
+++ b/golf2/apps/.gitignore
@@ -1,0 +1,17 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Specifically whitelist the .cargo/ directory, so that ripgrep will search it
+# (otherwise, ripgrep skips it because it is hidden).
+!.cargo/

--- a/golf2/apps/h1b_tests/.gitignore
+++ b/golf2/apps/h1b_tests/.gitignore
@@ -1,0 +1,3 @@
+build/
+Cargo.lock
+target/

--- a/golf2/apps/h1b_tests/Cargo.toml
+++ b/golf2/apps/h1b_tests/Cargo.toml
@@ -1,0 +1,33 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[package]
+name = "h1b_tests"
+version = "0.1.0"
+authors = ["jrvanwhy <jrvanwhy@google.com>"]
+publish = false
+
+[dependencies]
+tock = { path = "../../../third_party/libtock-rs" }
+
+[profile.dev]
+panic = "abort"
+opt-level = "z"
+debug = true
+
+[profile.release]
+panic = "abort"
+lto = true
+opt-level = "z"
+debug = true

--- a/golf2/apps/h1b_tests/Makefile
+++ b/golf2/apps/h1b_tests/Makefile
@@ -1,0 +1,57 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Supported targets (these correspond to cargo commands)
+#   all (default) -- alias for build
+#   build
+#   check
+#   clean
+#   doc
+
+.PHONY: all
+all: build
+
+.PHONY: build
+build: build/cortex-m3/cortex-m3/cortex-m3.tbf
+
+.PHONY: check
+check:
+	cargo check --release
+
+.PHONY: clean
+clean:
+	cargo clean
+	rm -rf build/
+
+.PHONY: doc
+doc:
+	cargo doc --release
+
+# Builds the Tock Binary Format (TBF) executable from the cargo-generated ELF
+# file. We use elf2tab -- it will create the tbf file as a side-effect. It
+# creates it in the same directory as the elf files, while the golf2 Makefile
+# expects it at build/cortex-m3/cortex-m3/cortex-m3.tbf, so we manually move the
+# file over afterwards.
+build/cortex-m3/cortex-m3/cortex-m3.tbf: target/thumbv7m-none-eabi/release/h1b_tests
+	mkdir -p build/cortex-m3/cortex-m3
+	elf2tab -n "h1b_tests" -o build/cortex-m3/cortex-m3/cortex-m3.tab $^ \
+		--stack=2048 --app-heap=1024 --kernel-heap=1024
+	mv target/thumbv7m-none-eabi/release/h1b_tests.tbf \
+		build/cortex-m3/cortex-m3/cortex-m3.tbf
+
+# Builds the h1b_tests Elf file using cargo. Marked as phony because we rely on
+# Cargo to determine when to rebuild.
+.PHONY: target/thumbv7m-none-eabi/release/h1b_tests
+target/thumbv7m-none-eabi/release/h1b_tests:
+	cargo build --release

--- a/golf2/apps/h1b_tests/src/main.rs
+++ b/golf2/apps/h1b_tests/src/main.rs
@@ -19,13 +19,15 @@ extern crate alloc;
 extern crate tock;
 
 fn main() {
-	use tock::console::Console;
+    use tock::console::Console;
 
-	let mut console = Console::new();
-	loop {
-		use core::fmt::Write;
-		use tock::timer;
-		console.write_str("Hello, World!\n").expect("Failed console write");
-		timer::sleep(timer::Duration::from_ms(1000));
-	}
+    let mut console = Console::new();
+    loop {
+        use core::fmt::Write;
+        use tock::timer;
+        console
+            .write_str("Hello, World!\n")
+            .expect("Failed console write");
+        timer::sleep(timer::Duration::from_ms(1000));
+    }
 }

--- a/golf2/apps/h1b_tests/src/main.rs
+++ b/golf2/apps/h1b_tests/src/main.rs
@@ -1,0 +1,31 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![feature(alloc)]
+#![no_std]
+
+extern crate alloc;
+extern crate tock;
+
+fn main() {
+	use tock::console::Console;
+
+	let mut console = Console::new();
+	loop {
+		use core::fmt::Write;
+		use tock::timer;
+		console.write_str("Hello, World!\n").expect("Failed console write");
+		timer::sleep(timer::Duration::from_ms(1000));
+	}
+}


### PR DESCRIPTION
h1b_tests is the first Rust app for Tock-on-Titan, and is currently just a hello world.