### PR TITLE
Add a rust-toolchain symlink so rustup will automatically pick the correct nightly.

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,1 @@
+third_party/tock/rust-toolchain


### PR DESCRIPTION
After this is merged, we will no longer need to set a rustup override as part of initial setup (or maintenance) of the repo.