### PR TITLE
Debug driver -- number-printing syscall driver for relocation debugging

### DIFF
--- a/golf2/src/debug.rs
+++ b/golf2/src/debug.rs
@@ -1,0 +1,44 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Syscall driver for libtock-rs debugging. Allows applications to print 1, 2,
+// or 3 integers to the console using only the command syscall. The integers are
+// passed through the minor number and command arguments. Unlike the console
+// driver, this does not rely on the allow syscall (useful because relocations
+// are not currently working). The syscall is nonblocking and does not produce
+// an event. Calling it multiple times in quick succession will not work -- it
+// fills up a buffer and stops printing more messages. The driver number is
+// 0x80000001.
+
+use kernel::{AppId, Driver, ReturnCode};
+
+pub const DRIVER_NUM: usize = 0x80000001;
+pub struct Debug {}
+
+impl Debug {
+    pub fn new() -> Debug {
+        Debug {}
+    }
+}
+
+impl Driver for Debug {
+    fn command(&self, minor_num: usize, r2: usize, r3: usize, _caller_id: AppId) -> ReturnCode {
+        match (minor_num, r2, r3) {
+            (_, 0, 0) => debug!("{}", minor_num),
+            (_, _, 0) => debug!("{} {}", minor_num, r2),
+            (_, _, _) => debug!("{} {} {}", minor_num, r2, r3),
+        }
+        ReturnCode::SUCCESS
+    }
+}

--- a/golf2/src/debug_syscall.rs
+++ b/golf2/src/debug_syscall.rs
@@ -24,15 +24,15 @@
 use kernel::{AppId, Driver, ReturnCode};
 
 pub const DRIVER_NUM: usize = 0x80000001;
-pub struct Debug {}
+pub struct UintPrinter {}
 
-impl Debug {
-    pub fn new() -> Debug {
-        Debug {}
+impl UintPrinter {
+    pub fn new() -> UintPrinter {
+        UintPrinter {}
     }
 }
 
-impl Driver for Debug {
+impl Driver for UintPrinter {
     fn command(&self, minor_num: usize, r2: usize, r3: usize, _caller_id: AppId) -> ReturnCode {
         match (minor_num, r2, r3) {
             (_, 0, 0) => debug!("{}", minor_num),

--- a/golf2/src/main.rs
+++ b/golf2/src/main.rs
@@ -33,7 +33,7 @@ pub mod digest;
 pub mod aes;
 pub mod dcrypto;
 pub mod dcrypto_test;
-pub mod debug;
+pub mod debug_syscall;
 
 use capsules::console;
 use capsules::virtual_uart::{UartDevice, UartMux};
@@ -73,7 +73,7 @@ pub struct Golf {
     aes: &'static aes::AesDriver<'static>,
     //rng: &'static capsules::rng::SimpleRng<'static, h1b::trng::Trng<'static>>,
     dcrypto: &'static dcrypto::DcryptoDriver<'static>,
-    debug: debug::Debug,
+    uint_printer: debug_syscall::UintPrinter,
 }
 
 static mut STRINGS: [StringDescriptor; 7] = [
@@ -256,7 +256,7 @@ pub unsafe fn reset_handler() {
         aes: aes,
         dcrypto: dcrypto,
 //        rng: rng,
-        debug: debug::Debug::new(),
+        uint_printer: debug_syscall::UintPrinter::new(),
     };
 
     // ** GLOBALSEC **
@@ -348,7 +348,7 @@ impl Platform for Golf {
 //            capsules::rng::DRIVER_NUM   => f(Some(self.rng)),
             kernel::ipc::DRIVER_NUM       => f(Some(&self.ipc)),
             dcrypto::DRIVER_NUM           => f(Some(self.dcrypto)),
-            debug::DRIVER_NUM             => f(Some(&self.debug)),
+            debug_syscall::DRIVER_NUM     => f(Some(&self.uint_printer)),
             _ =>  f(None),
         }
     }

--- a/golf2/src/main.rs
+++ b/golf2/src/main.rs
@@ -332,6 +332,29 @@ pub unsafe fn reset_handler() {
     kernel.kernel_loop(&golf2, chip, Some(&golf2.ipc), &main_cap);
 }
 
+// Syscall driver for libtock-rs debugging. Allows applications to print 1, 2,
+// or 3 integers to the console using only the command syscall. The integers are
+// passed through the minor number and command arguments. Unlike the console
+// driver, this does not rely on the allow syscall (useful because relocations
+// are not currently working). The syscall is nonblocking and does not produce
+// an event. Calling it multiple times in quick succession will not work -- it
+// fills up a buffer and stops printing more messages. The driver number is
+// 0x80000001.
+struct DebugDriver {}
+static DEBUG_DRIVER: DebugDriver = DebugDriver{};
+
+impl kernel::Driver for DebugDriver {
+    fn command(&self, minor_num: usize, r2: usize, r3: usize, _caller_id: kernel::AppId) -> kernel::ReturnCode {
+        match (minor_num, r2, r3) {
+            (_, 0, 0) => debug!("{}", minor_num),
+            (_, _, 0) => debug!("{} {}", minor_num, r2),
+            (_, _, _) => debug!("{} {} {}", minor_num, r2, r3),
+        }
+        kernel::ReturnCode::SUCCESS
+    }
+}
+
+
 impl Platform for Golf {
     fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
         where F: FnOnce(Option<&kernel::Driver>) -> R
@@ -345,6 +368,7 @@ impl Platform for Golf {
 //            capsules::rng::DRIVER_NUM   => f(Some(self.rng)),
             kernel::ipc::DRIVER_NUM       => f(Some(&self.ipc)),
             dcrypto::DRIVER_NUM           => f(Some(self.dcrypto)),
+            0x80000001                    => f(Some(&DEBUG_DRIVER)),
             _ =>  f(None),
         }
     }

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,1 @@
+third_party/tock/rust-toolchain


### PR DESCRIPTION
This adds a "debug" driver which only relies on the `command` syscall. This driver is for Rust userspace debugging; because relocations do not currently work, the standard libtock-rs console functionality is unreliable.

It enables an application to print 1, 2, or 3 unsigned integers using a single system call. It can be removed once Rust application support and libtock-rs console support are sufficiently reliable.