### PR TITLE
Add a test harness, switching h1b_tests to a test executor.

### DIFF
--- a/golf2/apps/h1b_tests/Makefile
+++ b/golf2/apps/h1b_tests/Makefile
@@ -53,7 +53,18 @@ build/cortex-m3/cortex-m3/cortex-m3.tbf: target/thumbv7m-none-eabi/release/h1b_t
 		build/cortex-m3/cortex-m3/cortex-m3.tbf
 
 # Builds the h1b_tests Elf file using cargo. Marked as phony because we rely on
-# Cargo to determine when to rebuild.
+# Cargo to determine when to rebuild. We build using `cargo test` so that rustc
+# builds the test code and tests list. We can't just pass --test to rustc
+# through rustflags because that causes cargo to fail to parse rustc's output
+# for some invocations. Cargo names the test h1b_test-<hex string>, and outputs
+# another file with the same name plus ".d", so we need to use find with a
+# regexp to locate the test executable. Note that we first clear out existing
+# test binaries because Cargo does not do so; the `find` call relies on there
+# only being a single test binary.
 .PHONY: target/thumbv7m-none-eabi/release/h1b_tests
 target/thumbv7m-none-eabi/release/h1b_tests:
-	cargo build --release
+	rm -f target/thumbv7m-none-eabi/release/h1b_tests-*
+	cargo test --no-run --release
+	find target/thumbv7m-none-eabi/release/ -maxdepth 1 \
+		-regex 'target/thumbv7m-none-eabi/release/h1b_tests-[^.]+' \
+		-exec cp '{}' target/thumbv7m-none-eabi/release/h1b_tests ';'

--- a/golf2/apps/h1b_tests/src/lib.rs
+++ b/golf2/apps/h1b_tests/src/lib.rs
@@ -19,11 +19,10 @@ extern crate alloc;
 extern crate simple_print;
 extern crate tock;
 
-fn main() {
+#[test]
+fn basic_test() -> bool {
     use simple_print::{console,hex};
-    console!("Cat video count: ", 9001, "\nWhere we eat: ", hex(51966usize), "\n");
-    loop {
-        tock::timer::sleep(tock::timer::Duration::from_ms(1000));
-        console!("tick\n");
-    }
+    console!("Cat video count: ", 9001, "\nWhat we eat: ", hex(3405705229usize), "\n");
+    tock::timer::sleep(tock::timer::Duration::from_ms(1000));
+    true
 }

--- a/golf2/apps/h1b_tests/src/main.rs
+++ b/golf2/apps/h1b_tests/src/main.rs
@@ -16,18 +16,14 @@
 #![no_std]
 
 extern crate alloc;
+extern crate simple_print;
 extern crate tock;
 
 fn main() {
-    use tock::console::Console;
-
-    let mut console = Console::new();
+    use simple_print::{console,hex};
+    console!("Cat video count: ", 9001, "\nWhere we eat: ", hex(51966usize), "\n");
     loop {
-        use core::fmt::Write;
-        use tock::timer;
-        console
-            .write_str("Hello, World!\n")
-            .expect("Failed console write");
-        timer::sleep(timer::Duration::from_ms(1000));
+        tock::timer::sleep(tock::timer::Duration::from_ms(1000));
+        console!("tick\n");
     }
 }

--- a/simple_print/Cargo.toml
+++ b/simple_print/Cargo.toml
@@ -13,22 +13,11 @@
 # limitations under the License.
 
 [package]
-name = "h1b_tests"
+name = "simple_print"
 version = "0.1.0"
 authors = ["jrvanwhy <jrvanwhy@google.com>"]
+edition = "2018"
 publish = false
 
 [dependencies]
-simple_print = { path = "../../../simple_print" }
-tock = { path = "../../../third_party/libtock-rs" }
-
-[profile.dev]
-panic = "abort"
-opt-level = "z"
-debug = true
-
-[profile.release]
-panic = "abort"
-lto = true
-opt-level = "z"
-debug = true
+tock = { path = "../third_party/libtock-rs" }

--- a/simple_print/src/lib.rs
+++ b/simple_print/src/lib.rs
@@ -1,0 +1,123 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![no_std]
+#![feature(alloc)]
+
+/// Tock userspace library for simple console printing/debugging. This avoids
+/// dynamic polymorphism and as a result is much lighter weight than core::fmt.
+/// Its interface is inspired by absl::StrCat.
+
+// Although currently it is very malloc-happy, it is designed to be adapted to
+// minimize allocations. It should be possible to print numeric values using
+// only fixed-size stack-allocated buffers with no change to the public API.
+// Similarly, once we have some form of allow_const (i.e. an allow() syscall
+// that can point into RAM or flash), we can remove the allocation from the path
+// that prints a &str.
+//
+// The downside of this design is it produces a sequence of console writes
+// rather than allocating a buffer and doing the write in a single syscall,
+// which may hurt performance.
+
+extern crate alloc;
+
+use tock::console::Console;
+
+/// Prints a sequence of values to the console.
+///
+/// # Example
+/// ```
+/// console!("Cat video count: ", 9001, "\nWhere we eat: ", hex(51966), "\n");
+/// ```
+#[macro_export]
+macro_rules! console {
+    ($($v:expr),*) => {
+        { $(simple_print::Printable::print($v);)* }
+    };
+}
+
+/// Marks that a value should be printed in hexadecimal rather than in decimal.
+///
+/// # Example
+/// ```
+/// console!("Address of 8: ", hex(&8));
+/// ```
+pub fn hex<T: HexPrintable>(value: T) -> Hex {
+    Hex { value: value.to_u32() }
+}
+
+// -----------------------------------------------------------------------------
+// Implementation details below.
+// -----------------------------------------------------------------------------
+
+pub trait Printable {
+    fn print(self);
+}
+
+impl Printable for &str {
+    fn print(self) {
+        use core::fmt::Write;
+        // Tock's Console cannot fail.
+        let _ = Console.write_str(self);
+    }
+}
+
+impl Printable for alloc::string::String {
+    fn print(self) {
+        Console.write(self);
+    }
+}
+
+impl Printable for i32 {
+    fn print(self) {
+        Console.write(tock::fmt::i32_as_decimal(self));
+    }
+}
+
+impl Printable for u32 {
+    fn print(self) {
+        Console.write(tock::fmt::u32_as_decimal(self));
+    }
+}
+
+// Types that may be printed in hex. Currently libtock-rs only supports
+// formatting u32's as hex; for simplicity, we simply convert anything we'd like
+// to print to u32's.
+pub trait HexPrintable {
+    fn to_u32(self) -> u32;
+}
+
+pub struct Hex { value: u32 }
+
+impl Printable for Hex {
+    fn print(self) {
+        Console.write(tock::fmt::u32_as_hex(self.value));
+    }
+}
+
+impl HexPrintable for u32 {
+    fn to_u32(self) -> u32 { self }
+}
+
+impl HexPrintable for usize {
+    fn to_u32(self) -> u32 { self as u32 }
+}
+
+impl<T> HexPrintable for *const T {
+    fn to_u32(self) -> u32 { self as u32 }
+}
+
+impl<T> HexPrintable for &T {
+    fn to_u32(self) -> u32 { self as *const T as u32 }
+}

--- a/test_harness/Cargo.toml
+++ b/test_harness/Cargo.toml
@@ -13,25 +13,12 @@
 # limitations under the License.
 
 [package]
-name = "h1b_tests"
+name = "test"
 version = "0.1.0"
 authors = ["jrvanwhy <jrvanwhy@google.com>"]
+edition = "2018"
 publish = false
 
 [dependencies]
-simple_print = { path = "../../../simple_print" }
-tock = { path = "../../../third_party/libtock-rs" }
-
-[dev-dependencies]
-test = { path = "../../../test_harness" }
-
-[profile.dev]
-panic = "abort"
-opt-level = "z"
-debug = true
-
-[profile.release]
-panic = "abort"
-lto = true
-opt-level = "z"
-debug = true
+simple_print = { path = "../simple_print" }
+tock = { path = "../third_party/libtock-rs" }

--- a/test_harness/src/lib.rs
+++ b/test_harness/src/lib.rs
@@ -1,0 +1,101 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Test harness that can run as a Tock application. Note that the application
+// itself should be a library crate, as the Rust test harness includes main().
+// Relies on internal details of rustc, so this may break during toolchain
+// updates.
+
+#![no_std]
+
+// TODO: Implement require!() and verify!() macros (should correspond to
+// ASSERT*() and EXPECT*() from gMock).
+
+// -----------------------------------------------------------------------------
+// #[test] macro support. As far as I (jrvanwhy) can tell, #[test] wraps each
+// test case in an outer function that interacts with the test crate. For the
+// following test definition:
+//     #[test]
+//     fn do_test() -> TestResult {
+//     }
+// the macro generates a wrapper that resembles:
+//     fn do_test_wrapper() -> /*depends on assert_test_result()*/ {
+//         assert_test_result(do_test())
+//     }
+// The wrapper is then referenced by StaticTestFn (note that the return type of
+// StaticTestFn must match the return type of assert_test_result()), which is
+// passed to test_main_static as part of TestDescAndFn.
+// -----------------------------------------------------------------------------
+
+// Converts the output of the test into a result for StaticTestFn. Note that
+// this may be generic, as long as the type parameters can be deduced from its
+// arguments and return type.
+pub fn assert_test_result(result: bool) -> bool { result }
+
+// -----------------------------------------------------------------------------
+// Compiler-generated test list types. The compiler generates a [&TestDescAndFn]
+// array and passes it to test_main_static.
+// -----------------------------------------------------------------------------
+
+// A ShouldPanic enum is required by rustc, but only No seems to be used.
+// #[should_panic] probably uses Yes, but isn't supported here (we assume panic
+// = "abort").
+pub enum ShouldPanic { No }
+
+// Interestingly, these must be tuple structs for tests to compile.
+pub struct StaticTestFn(pub fn() -> bool);
+pub struct StaticTestName(pub &'static str);
+
+pub struct TestDesc {
+    // Indicates a test case should run but not fail the overall test suite.
+    // This was introduced in https://github.com/rust-lang/rust/pull/42219. It
+    // is not expected to become stable:
+    // https://github.com/rust-lang/rust/issues/46488
+    pub allow_fail: bool,
+
+    pub ignore: bool,
+    pub name: StaticTestName,
+    pub should_panic: ShouldPanic,
+}
+
+pub struct TestDescAndFn {
+    pub desc: TestDesc,
+    pub testfn: StaticTestFn,
+}
+
+// The test harness's equivalent of main() (it is called by a compiler-generated
+// shim).
+pub fn test_main_static(tests: &[&TestDescAndFn]) {
+    use simple_print::console;
+    console!("Starting tests.\n");
+    let mut overall_success = true;
+    for test_case in tests {
+        // Skip ignored test cases.
+        let desc = &test_case.desc;
+        let name = desc.name.0;
+        if desc.ignore {
+            console!("Skipping ignored test ", name, "\n");
+            continue;
+        }
+
+        // Run the test.
+        console!("Running test ", name, "\n");
+        let succeeded = test_case.testfn.0();
+        console!("Finished test ", name, ". Result: ",
+               if succeeded { "succeeded" } else { "failed" }, ".\n");
+        overall_success &= succeeded;
+    }
+    console!("Testing complete. Result: ",
+           if overall_success { "succeeded" } else { "failed" }, "\n");
+}


### PR DESCRIPTION
This allows us to run Rust unit tests directly on Tock as an application. In future changes, I'll add a tool to make it easy for unit tests to do assertions and set expectations (`assert!()` panics so it cannot be used in these unit tests).