### PR TITLE
Rewrite of AES peripheral and system call driver.

### DIFF
--- a/golf2/src/aes.rs
+++ b/golf2/src/aes.rs
@@ -13,179 +13,124 @@
 // limitations under the License.
 
 use core::cell::Cell;
-use h1b::crypto::aes::{AesEngine, Interrupt, KeySize};
+use h1b::crypto::aes::AesEngine;
 use kernel::{AppId, Callback, Driver, Grant, ReturnCode, Shared, AppSlice};
+use kernel::common::cells::TakeCell;
 use kernel::hil::symmetric_encryption;
+use kernel::hil::symmetric_encryption::{AES128_BLOCK_SIZE, AES128_KEY_SIZE};
+use kernel::hil::symmetric_encryption::{AES128, AES128CBC, AES128Ctr, AES128Ecb};
 
 pub const DRIVER_NUM: usize = 0x40000;
 
-#[derive(Default)]
-struct Callbacks {
-    done_cipher: Option<Callback>,
-    done_key_expansion: Option<Callback>,
-    done_wipe_secrets: Option<Callback>,
-}
+pub static mut AES_BUF: [u8; AES128_BLOCK_SIZE] = [0; AES128_BLOCK_SIZE];
 
 #[derive(Default)]
 pub struct AppData {
     key: Option<AppSlice<Shared, u8>>,
     input_buffer: Option<AppSlice<Shared, u8>>,
     output_buffer: Option<AppSlice<Shared, u8>>,
-    callbacks: Callbacks,
+    iv_buffer: Option<AppSlice<Shared, u8>>,
+    callback: Option<Callback>,
 }
 
 pub struct AesDriver<'a> {
     device: &'a AesEngine<'a>,
     apps: Grant<AppData>,
     current_user: Cell<Option<AppId>>,
-    bytes_encrypted: Cell<usize>,
+    buffer: TakeCell<'a, [u8]>,
 }
 
 impl<'a> AesDriver<'a> {
-    pub fn new(device: &'a mut AesEngine<'a>, container: Grant<AppData>) -> AesDriver<'a> {
+    pub fn new(device: &'a mut AesEngine<'a>,
+               container: Grant<AppData>) -> AesDriver<'a> {
         AesDriver {
             device: device,
             apps: container,
             current_user: Cell::new(None),
-            bytes_encrypted: Cell::new(0),
+            buffer: TakeCell::empty(),
         }
     }
 
-    fn setup(&self, caller_id: AppId, key_size: usize) -> ReturnCode {
-        self.apps
-            .enter(caller_id, |app_data, _| {
-                let key_size = match key_size {
-                    0 => KeySize::KeySize128,
-                    1 => KeySize::KeySize192,
-                    2 => KeySize::KeySize256,
-                    _ => return ReturnCode::EINVAL,
-                };
+    // Register a buffer, which must be of size AES128_BLOCK_SIZE; if
+    // it is not the proper size, return the buffer in the
+    // Option. Return None if the buffer was correct.
+    pub fn initialize(&self,
+                      input_buffer: &'a mut [u8]) -> Option<&'a mut [u8]>  {
+        self.device.setup();
 
-                let raw_key = match app_data.key {
-                    Some(ref slice) => slice,
-                    None => return ReturnCode::EINVAL,
-                };
+        if input_buffer.len() != AES128_BLOCK_SIZE {
+            Some(input_buffer)
+        } else {
+            self.buffer.replace(input_buffer);
+            None
+        }
+    }
 
-                match (key_size, raw_key.len()) {
-                    (KeySize::KeySize128, 16) => {}
-                    (KeySize::KeySize192, 24) => {}
-                    (KeySize::KeySize256, 32) => {}
-                    _ => {
-                        debug!("Key size is wrong. Given {}, expected {:?}",
-                                 raw_key.len() * 8,
-                                 key_size);
-                        return ReturnCode::EINVAL;
+    fn run_aes(&self, caller_id: AppId) -> ReturnCode {
+        self.apps.enter(caller_id, |app_data, _| {
+            if app_data.input_buffer.is_none() {
+                debug!("Missing input buffer.\n");
+                return ReturnCode::ENOMEM;
+            } else if app_data.key.is_none() {
+                debug!("Missing application encryption key.\n");
+                return ReturnCode::ENOMEM;
+            } else if self.buffer.is_none() {
+                debug!("Missing kernel buffer.\n");
+                return ReturnCode::ENOMEM;
+            }
+            let key = app_data.key.take();
+            key.map(|key| {
+                if key.len() == AES128_KEY_SIZE {
+                    self.device.set_key(key.as_ref());
+                }
+                app_data.key = Some(key);
+            });
+
+            // Copy application data into the kernel buffer
+            self.buffer.map(|buf| {
+                app_data.input_buffer.as_ref().map(|src| {
+                    for (i, c) in src.as_ref()[0..AES128_BLOCK_SIZE].iter().enumerate() {
+                        buf[i] = *c;
                     }
-                }
-
-                let mut key = [0; 8];
-                for (i, word) in raw_key.as_ref().chunks(4).enumerate() {
-                    key[i] = word.iter()
-                        .map(|b| *b as u32)
-                        .enumerate()
-                        .fold(0, |accm, (i, byte)| accm | (byte << (i * 8)));
-                }
-
-                if self.current_user.get().is_some() {
-                    return ReturnCode::EBUSY;
-                }
-                self.current_user.set(Some(caller_id));
-
-                self.device.setup(key_size, &key);
-
+                });
+            });
+            let buf = self.buffer.take().unwrap();
+            let opt =  AES128::crypt(self.device, None, buf, 0, AES128_BLOCK_SIZE);
+            if let Some((rcode, _ibufopt, obuf)) = opt {
+                debug!("Failed to invoke AES encryption: {:?}", rcode);
+                self.buffer.put(Some(obuf));
+                rcode
+            } else {
                 ReturnCode::SUCCESS
-            })
-            .unwrap_or_else(|err| err.into())
-    }
-
-    fn set_encrypt_mode(&self, caller_id: AppId, do_encrypt: usize) -> ReturnCode {
-        self.apps
-            .enter(caller_id, |_, _| {
-                match self.current_user.get() {
-                    Some(cur) if cur.idx() == caller_id.idx() => {}
-                    _ => return ReturnCode::EBUSY,
-                }
-
-                self.device.set_encrypt_mode(do_encrypt != 0);
-
-                ReturnCode::SUCCESS
-            })
-            .unwrap_or(ReturnCode::FAIL)
-    }
-
-    fn crypt(&self, caller_id: AppId) -> ReturnCode {
-        self.apps
-            .enter(caller_id, |app_data, _| {
-                match self.current_user.get() {
-                    Some(cur) if cur.idx() == caller_id.idx() => {}
-                    _ => return ReturnCode::EBUSY,
-                }
-
-                let input_buffer = match app_data.input_buffer {
-                    Some(ref slice) => slice,
-                    None => return ReturnCode::EINVAL,
-                };
-                let count = self.device.crypt(input_buffer.as_ref());
-                self.bytes_encrypted.set(count);
-                return ReturnCode::SUCCESS;
-            }).unwrap_or_else(|err| err.into())
-    }
-
-    fn read_data(&self, caller_id: AppId) -> Result<isize, ReturnCode> {
-        self.apps
-            .enter(caller_id, |app_data, _| {
-                match self.current_user.get() {
-                    Some(cur) if cur.idx() == caller_id.idx() => {}
-                    _ => return Err(ReturnCode::EBUSY),
-                }
-
-                let output_buffer = match app_data.output_buffer {
-                    Some(ref mut slice) => slice,
-                    None => return Err(ReturnCode::ENOMEM),
-                };
-
-                Ok(self.device.read_data(output_buffer.as_mut()) as isize)
-            })
-            .unwrap_or(Err(ReturnCode::FAIL))
-    }
-
-    fn finish(&self, caller_id: AppId) -> ReturnCode {
-        self.apps
-            .enter(caller_id, |_, _| {
-                match self.current_user.get() {
-                    Some(cur) if cur.idx() == caller_id.idx() => {}
-                    _ => return ReturnCode::EBUSY,
-                }
-
-                self.current_user.set(None);
-
-                self.device.finish();
-
-                ReturnCode::SUCCESS
-            })
-            .unwrap_or(ReturnCode::FAIL)
-    }
-
-    fn register(&self,
-                interrupt: Interrupt,
-                callback: Option<Callback>,
-                app_id: AppId,
-    ) -> ReturnCode {
-        self.apps
-            .enter(app_id, |app_data, _| {
-                let ref mut cb = app_data.callbacks;
-                match interrupt {
-                    Interrupt::DoneCipher => cb.done_cipher = callback,
-                    Interrupt::DoneKeyExpansion => cb.done_key_expansion = callback,
-                    Interrupt::DoneWipeSecrets => cb.done_wipe_secrets = callback,
-                    _ => return ReturnCode::ENOSUPPORT,
-                }
-
-                ReturnCode::SUCCESS
-            })
-            .unwrap_or_else(|err| err.into())
+            }
+        }).unwrap_or(ReturnCode::ENOMEM)
     }
 }
+
+
+impl<'a> symmetric_encryption::Client<'a> for AesDriver<'a> {
+    fn crypt_done(&self, _source: Option<&'a mut [u8]>, output: &'a mut [u8]) {
+        self.current_user.get().map(|current_user| {
+            let _ = self.apps.enter(current_user, move |app_data, _| {
+                if let Some(ref mut slice) = app_data.output_buffer {
+                    self.device.read_data(slice.as_mut());
+                }
+                let val = {
+                    if let Some(ref mut slice) = app_data.input_buffer {
+                        self.device.read_data(slice.as_mut())
+                    } else {
+                        0
+                    }
+                };
+                self.current_user.set(None);
+                app_data.callback.map(|mut cb| cb.schedule(val, 0, 0));
+            });
+        });
+        self.buffer.replace(output);
+    }
+}
+
+
 
 impl<'a> Driver for AesDriver<'a> {
     fn subscribe(&self,
@@ -194,32 +139,53 @@ impl<'a> Driver for AesDriver<'a> {
                  app_id: AppId,
     ) -> ReturnCode {
         match subscribe_num {
-            0 => self.register(Interrupt::DoneCipher, callback, app_id),
-            1 => self.register(Interrupt::DoneKeyExpansion, callback, app_id),
-            2 => self.register(Interrupt::DoneWipeSecrets, callback, app_id),
+            0 => {
+                self.apps.enter(app_id, |app_data, _| {
+                    app_data.callback = callback;
+                    ReturnCode::SUCCESS
+                }).unwrap_or(ReturnCode::ENOMEM)
+            }
             _ => ReturnCode::ENOSUPPORT
         }
     }
 
-    fn command(&self, command_num: usize, arg1: usize, _: usize, caller_id: AppId) -> ReturnCode {
+    fn command(&self, command_num: usize, _arg1: usize, _: usize, caller_id: AppId) -> ReturnCode {
+        if self.current_user.get() == None {
+            self.current_user.set(Some(caller_id));
+        }
         match command_num {
-
             0 /* Check if present */ => ReturnCode::SUCCESS,
-            1 /* init encryption */ => self.setup(caller_id, arg1),
-            2 /* start encryption */ => {
-                self.crypt(caller_id)
-            }
-            3 /* read data */ => {
-                match self.read_data(caller_id) {
-                    Ok(_) => ReturnCode::SUCCESS,
-                    Err(e) => e
-                }
-            }
-            4 /* finish encryption */ => self.finish(caller_id),
-            5 /* set encryption mode */ => {
-                self.set_encrypt_mode(caller_id, arg1)
+            1 /* encrypt ECB */ => {
+                self.device.set_mode_aes128ecb(true);
+                self.run_aes(caller_id)
             },
-            _ => ReturnCode::ENOSUPPORT,
+            2 /* decrypt ECB */ => {
+                self.device.set_mode_aes128ecb(false);
+                self.run_aes(caller_id)
+            }
+            3 | 4 /* encrypt/decrypt CTR */ => {
+                self.apps.enter(caller_id, |app_data, _| {
+                    self.device.set_mode_aes128ctr(true);
+                    let buffer = app_data.iv_buffer.take();
+                    buffer.map_or(ReturnCode::ENOMEM, |iv| {
+                        self.device.set_iv(iv.as_ref());
+                        app_data.iv_buffer = Some(iv);
+                        self.run_aes(caller_id)
+                    })
+                }).unwrap_or(ReturnCode::ENOMEM)
+            }
+            5 /* encrypt CBC */ => {
+                self.device.set_mode_aes128cbc(true);
+                self.run_aes(caller_id)
+            },
+            6 /* decrypt CBC */ => {
+                self.device.set_mode_aes128cbc(false);
+                self.run_aes(caller_id)
+            },
+            _ => {
+                self.current_user.set(None);
+                ReturnCode::ENOSUPPORT
+            }
         }
     }
 
@@ -233,7 +199,15 @@ impl<'a> Driver for AesDriver<'a> {
                     // Key
                     self.apps
                         .enter(app_id, |app_data, _| {
-                            app_data.key = slice;
+                            if let Some(s) = slice {
+                                if s.len() != AES128_KEY_SIZE {
+                                    return ReturnCode::ESIZE;
+                                }
+                                app_data.key = Some(s);
+                            } else {
+                                app_data.key = slice;
+                            }
+
                             ReturnCode::SUCCESS
                         })
                         .unwrap_or(ReturnCode::FAIL)
@@ -242,7 +216,14 @@ impl<'a> Driver for AesDriver<'a> {
                     // Input Buffer
                     self.apps
                         .enter(app_id, |app_data, _| {
-                            app_data.input_buffer = slice;
+                            if let Some(s) = slice {
+                                if s.len() != AES128_BLOCK_SIZE {
+                                    return ReturnCode::ESIZE;
+                                }
+                                app_data.input_buffer = Some(s);
+                            } else {
+                                app_data.input_buffer = slice;
+                            }
                             ReturnCode::SUCCESS
                         })
                         .unwrap_or(ReturnCode::FAIL)
@@ -251,13 +232,37 @@ impl<'a> Driver for AesDriver<'a> {
                     // Output Buffer
                     self.apps
                         .enter(app_id, |app_data, _| {
-                            app_data.output_buffer = slice;
+                            if let Some(s) = slice {
+                                if s.len() != AES128_BLOCK_SIZE {
+                                    return ReturnCode::ESIZE;
+                                }
+                                app_data.output_buffer = Some(s);
+                            } else {
+                                app_data.output_buffer = slice;
+                            }
                             ReturnCode::SUCCESS
                         })
                         .unwrap_or(ReturnCode::FAIL)
                 }
-                _ => ReturnCode::ENOSUPPORT,
-            }
+                3 => {
+                    // Initialization vector/Counter
+                    self.apps
+                        .enter(app_id, |app_data, _| {
+                            if let Some(s) = slice {
+                                if s.len() != AES128_BLOCK_SIZE {
+                                    return ReturnCode::ESIZE;
+                                }
+                                app_data.iv_buffer = Some(s);
+                            } else {
+                                app_data.iv_buffer = slice;
+                            }
+                            ReturnCode::SUCCESS
+                        })
+                        .unwrap_or(ReturnCode::FAIL)
+                }
+            _ => ReturnCode::ENOSUPPORT,
+
+        }
     }
 }
 

--- a/golf2/src/main.rs
+++ b/golf2/src/main.rs
@@ -47,15 +47,15 @@ use h1b::crypto::dcrypto::Dcrypto;
 use h1b::usb::{Descriptor, StringDescriptor};
 
 // State for loading apps
-const NUM_PROCS: usize = 2;
+const NUM_PROCS: usize = 1;
 
 // how should the kernel respond when a process faults
 const FAULT_RESPONSE: kernel::procs::FaultResponse = kernel::procs::FaultResponse::Panic;
 
 #[link_section = ".app_memory"]
-static mut APP_MEMORY: [u8; 16384] = [0; 16384];
+static mut APP_MEMORY: [u8; 32768] = [0; 32768];
 
-static mut PROCESSES: [Option<&'static kernel::procs::ProcessType>; NUM_PROCS] = [None, None];
+static mut PROCESSES: [Option<&'static kernel::procs::ProcessType>; NUM_PROCS] = [None];
 
 /// Dummy buffer that causes the linker to reserve enough space for the stack.
 #[no_mangle]
@@ -231,6 +231,7 @@ pub unsafe fn reset_handler() {
         aes::AesDriver,
         aes::AesDriver::new(&mut h1b::crypto::aes::KEYMGR0_AES, kernel.create_grant(&grant_cap)));
     h1b::crypto::aes::KEYMGR0_AES.set_client(aes);
+    aes.initialize(&mut aes::AES_BUF);
 
     h1b::crypto::dcrypto::DCRYPTO.initialize();
     let dcrypto = static_init!(


### PR DESCRIPTION
This is a rewrite of the H1B AES peripheral driver and the associated system call capsule. It now follows the standard/mainline AES interface. The major change over the standard Tock API is the addition of ECB mode, which is required for FIPS. This is through a trait defined in `h1b::aes`. This PR brings the system call driver in line with #25 (the userspace component).