### PR TITLE
Put the userspace Rust code into a Cargo workspace.

### DIFF
--- a/userspace/.gitignore
+++ b/userspace/.gitignore
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 build/
+Cargo.lock
 
 # Specifically whitelist the .cargo/ directory, so that ripgrep will search it
 # (otherwise, ripgrep skips it because it is hidden).

--- a/userspace/Cargo.toml
+++ b/userspace/Cargo.toml
@@ -1,0 +1,47 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Workspace for tock-on-titan userspace Rust code. Note that this directory
+# also contains C libraries and applications, which are not handled by Cargo.
+
+# Used by h1b_tests, as h1b_tests is built as a test binary.
+[profile.bench]
+codegen-units = 1
+lto = true
+opt-level = "z"
+panic = "abort"
+
+# Used by most Tock application binaries.
+[profile.release]
+codegen-units = 1
+lto = true
+opt-level = "z"
+panic = "abort"
+
+# Used by h1b_tests' dependencies, as h1b_tests is built as a test binary.
+[profile.test]
+codegen-units = 1
+debug = false
+debug-assertions = false
+incremental = false
+lto = true
+opt-level = "z"
+panic = "unwind"
+
+[workspace]
+members = [
+	"h1b_tests",
+	"simple_fmt",
+	"test_harness",
+]

--- a/userspace/h1b_tests/.gitignore
+++ b/userspace/h1b_tests/.gitignore
@@ -1,3 +1,2 @@
 build/
 Cargo.lock
-target/

--- a/userspace/h1b_tests/Cargo.toml
+++ b/userspace/h1b_tests/Cargo.toml
@@ -25,14 +25,3 @@ simple_print = { path = "../../simple_print" }
 
 [dev-dependencies]
 test = { path = "../test_harness" }
-
-[profile.dev]
-panic = "abort"
-opt-level = "z"
-debug = true
-
-[profile.release]
-panic = "abort"
-lto = true
-opt-level = "z"
-debug = true

--- a/userspace/h1b_tests/Makefile
+++ b/userspace/h1b_tests/Makefile
@@ -43,13 +43,13 @@ doc:
 # creates it in the same directory as the elf files, while the golf2 Makefile
 # expects it at build/cortex-m3/cortex-m3/cortex-m3.tbf, so we manually move the
 # file over afterwards.
-build/cortex-m3/cortex-m3/cortex-m3.tbf: target/thumbv7m-none-eabi/release/h1b_tests
+build/cortex-m3/cortex-m3/cortex-m3.tbf: ../target/thumbv7m-none-eabi/release/h1b_tests
 	mkdir -p build/cortex-m3/cortex-m3
 	cd ../../third_party/elf2tab && cargo run --release -- -n "h1b_tests" \
 		-o ../../userspace/h1b_tests/build/cortex-m3/cortex-m3/cortex-m3.tab \
 		../../userspace/h1b_tests/$^ --stack=2048 --app-heap=1024 \
 		--kernel-heap=1024 --protected-region-size=64
-	mv target/thumbv7m-none-eabi/release/h1b_tests.tbf \
+	mv ../target/thumbv7m-none-eabi/release/h1b_tests.tbf \
 		build/cortex-m3/cortex-m3/cortex-m3.tbf
 
 # Builds the h1b_tests Elf file using cargo. Marked as phony because we rely on
@@ -61,10 +61,10 @@ build/cortex-m3/cortex-m3/cortex-m3.tbf: target/thumbv7m-none-eabi/release/h1b_t
 # regexp to locate the test executable. Note that we first clear out existing
 # test binaries because Cargo does not do so; the `find` call relies on there
 # only being a single test binary.
-.PHONY: target/thumbv7m-none-eabi/release/h1b_tests
-target/thumbv7m-none-eabi/release/h1b_tests:
-	rm -f target/thumbv7m-none-eabi/release/h1b_tests-*
+.PHONY: ../target/thumbv7m-none-eabi/release/h1b_tests
+../target/thumbv7m-none-eabi/release/h1b_tests:
+	rm -f ../target/thumbv7m-none-eabi/release/h1b_tests-*
 	cargo test --no-run --release
-	find target/thumbv7m-none-eabi/release/ -maxdepth 1 \
-		-regex 'target/thumbv7m-none-eabi/release/h1b_tests-[^.]+' \
-		-exec cp '{}' target/thumbv7m-none-eabi/release/h1b_tests ';'
+	find ../target/thumbv7m-none-eabi/release/ -maxdepth 1 \
+		-regex '../target/thumbv7m-none-eabi/release/h1b_tests-[^.]+' \
+		-exec cp '{}' ../target/thumbv7m-none-eabi/release/h1b_tests ';'

--- a/userspace/layout.ld
+++ b/userspace/layout.ld
@@ -20,4 +20,4 @@ MEMORY {
 
 MPU_MIN_ALIGN = 8K;
 
-INCLUDE ../../third_party/libtock-rs/layout.ld
+INCLUDE ../third_party/libtock-rs/layout.ld

--- a/userspace/simple_fmt/Cargo.toml
+++ b/userspace/simple_fmt/Cargo.toml
@@ -23,11 +23,3 @@ publish = false
 
 [dev-dependencies]
 rayon = "1.0.3"
-
-# Run tests with optimization because the tests are very slow (and the compile
-# time fast).
-[profile.test]
-codegen-units = 1
-debug = false
-lto = true
-opt-level = 3


### PR DESCRIPTION
This will increase re-use of compilation artifacts for Rust libraries, and removes the need to specify compilation options on a per-binary basis.