### PR TITLE
Remove Cargo.lock from h1b_tests' .gitignore.

### DIFF
--- a/userspace/h1b_tests/.gitignore
+++ b/userspace/h1b_tests/.gitignore
@@ -1,2 +1,1 @@
 build/
-Cargo.lock


### PR DESCRIPTION
h1b_tests is now in a workspace, so it uses the workspace's Cargo.lock.