### PR TITLE
Update elf2tab

### DIFF
--- a/third_party/Build.mk
+++ b/third_party/Build.mk
@@ -26,7 +26,7 @@ third_party/build: build/cargo-host/release/elf2tab
 .PHONY: third_party/check
 third_party/check:
 	cd third_party/elf2tab && \
-		CARGO_BUILD_TARGET_DIR="../../build/cargo-host" cargo check -Z offline
+		CARGO_BUILD_TARGET_DIR="../../build/cargo-host" cargo check
 
 .PHONY: third_party/devicetests
 third_party/devicetests:
@@ -34,16 +34,16 @@ third_party/devicetests:
 .PHONY: third_party/doc
 third_party/doc:
 	cd third_party/elf2tab && \
-		CARGO_BUILD_TARGET_DIR="../../build/cargo-host" cargo doc -Z offline
+		CARGO_BUILD_TARGET_DIR="../../build/cargo-host" cargo doc
 
 .PHONY: third_party/localtests
 third_party/localtests:
 	cd third_party/elf2tab && \
-		CARGO_BUILD_TARGET_DIR="../../build/cargo-host" cargo test -Z offline
+		CARGO_BUILD_TARGET_DIR="../../build/cargo-host" cargo test
 
 
 .PHONY: build/cargo-host/release/elf2tab
 build/cargo-host/release/elf2tab:
 	cd third_party/elf2tab && \
 		CARGO_BUILD_TARGET_DIR="../../build/cargo-host" \
-		cargo build --release -Z offline
+		cargo build --release


### PR DESCRIPTION
Soon, I will add another Rust binary to the repository that will share its Cargo target directory with elf2tab. With a shared target/ directory we need to use the same toolchain. This elf2tab update changes the used toolchain from nightly-2018-04-19 to stable, allowing my future Rust binary to use the stable toolchain.

Depends on #73 