### PR TITLE
Add a locking mechanism to prevent concurrent uses of the dev board.

### DIFF
--- a/doc/build_system.md
+++ b/doc/build_system.md
@@ -77,6 +77,8 @@ directory structure of `build/`:
 ```
 build/
     cargo-host/         # Cargo-managed artifacts for the host machine
+    device_lock         # Lock file used with flock() to prevent concurrent uses
+                        # of the device.
     userspace/
         cargo/          # userspace/ Cargo workspace target tree
         h1b_tests/      # Non-cargo-managed files specific to h1b_tests

--- a/userspace/Build.mk
+++ b/userspace/Build.mk
@@ -72,7 +72,8 @@ $(foreach APP,$(C_APPS),userspace/$(APP)/localtests):
 .PHONY: $(foreach APP,$(C_APPS),userspace/$(APP)/program)
 $(foreach APP,$(C_APPS),userspace/$(APP)/program): userspace/%/program: \
 		build/userspace/%/full_image
-	$(TANGO_SPIFLASH) --verbose --input=build/userspace/$*/full_image
+	flock build/device_lock $(TANGO_SPIFLASH) --verbose \
+		--input=build/userspace/$*/full_image
 
 # TODO: Write a program to display the console output and call it here.
 .PHONY: $(foreach APP,$(C_APPS),userspace/$(APP)/program)

--- a/userspace/h1b_tests/Build.mk
+++ b/userspace/h1b_tests/Build.mk
@@ -32,7 +32,8 @@ userspace/h1b_tests/localtests:
 
 .PHONY: userspace/h1b_tests/program
 userspace/h1b_tests/program: build/userspace/h1b_tests/full_image
-	$(TANGO_SPIFLASH) --verbose --input=build/userspace/h1b_tests/full_image
+	flock build/device_lock $(TANGO_SPIFLASH) --verbose \
+		--input=build/userspace/h1b_tests/full_image
 
 # TODO: Implement a runner.
 .PHONY: userspace/h1b_tests/run


### PR DESCRIPTION
This will become important when `make devicetests` is functional, because it will prevent multiple tests from trying to image and run concurrently.

```
--------------
PR test state:
--------------
git rev-parse HEAD
4c8b6ccd5fe9a60d198485c0db13ceaa32cc8614
git status
On branch device-lock
Your branch is up to date with 'origin/device-lock'.

nothing to commit, working tree clean
```