### PR TITLE
Clarify what toolchains are used for each cargo/ directory in build/

### DIFF
--- a/doc/build_system.md
+++ b/doc/build_system.md
@@ -76,17 +76,20 @@ directory structure of `build/`:
 
 ```
 build/
-    cargo-host/         # Cargo-managed artifacts for the host machine
+    cargo-host/         # Cargo-managed artifacts for the host machine. Uses
+                        # elf2tab's toolchain version.
     device_lock         # Lock file used with flock() to prevent concurrent uses
                         # of the device.
     userspace/
-        cargo/          # userspace/ Cargo workspace target tree
+        cargo/          # userspace/ Cargo workspace target tree. Uses
+                        # libtock-rs's toolchain version.
         h1b_tests/      # Non-cargo-managed files specific to h1b_tests
         u2f_app/
         libgolf2/
         ...
     golf2/
         cargo/          # Cargo-managed artifacts for the golf2 Tock kernel.
+                        # Uses tock's toolchain version.
         ...
     third_party/
         chromiumos-ec/  # chromiumos-ec library artifacts.

--- a/doc/build_system.md
+++ b/doc/build_system.md
@@ -77,6 +77,8 @@ directory structure of `build/`:
 ```
 build/
     cargo-host/         # Cargo-managed artifacts for the host machine
+    device_lock         # Lock file used with flock() to prevent concurrent uses
+                        # of the device.
     userspace/
         cargo/          # userspace/ Cargo workspace target tree
         h1b_tests/      # Non-cargo-managed files specific to h1b_tests

--- a/golf2/rust-toolchain
+++ b/golf2/rust-toolchain
@@ -1,0 +1,1 @@
+../third_party/tock/rust-toolchain

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,0 @@
-third_party/tock/rust-toolchain

--- a/userspace/Build.mk
+++ b/userspace/Build.mk
@@ -72,7 +72,8 @@ $(foreach APP,$(C_APPS),userspace/$(APP)/localtests):
 .PHONY: $(foreach APP,$(C_APPS),userspace/$(APP)/program)
 $(foreach APP,$(C_APPS),userspace/$(APP)/program): userspace/%/program: \
 		build/userspace/%/full_image
-	$(TANGO_SPIFLASH) --verbose --input=build/userspace/$*/full_image
+	flock build/device_lock $(TANGO_SPIFLASH) --verbose \
+		--input=build/userspace/$*/full_image
 
 # TODO: Write a program to display the console output and call it here.
 .PHONY: $(foreach APP,$(C_APPS),userspace/$(APP)/program)

--- a/userspace/h1b_tests/Build.mk
+++ b/userspace/h1b_tests/Build.mk
@@ -32,7 +32,8 @@ userspace/h1b_tests/localtests:
 
 .PHONY: userspace/h1b_tests/program
 userspace/h1b_tests/program: build/userspace/h1b_tests/full_image
-	$(TANGO_SPIFLASH) --verbose --input=build/userspace/h1b_tests/full_image
+	flock build/device_lock $(TANGO_SPIFLASH) --verbose \
+		--input=build/userspace/h1b_tests/full_image
 
 # TODO: Implement a runner.
 .PHONY: userspace/h1b_tests/run


### PR DESCRIPTION
I also made the rust-toolchain files more local. There is no longer a top-level rust-toolchain file because there is no "overall" toolchain for the repository: it is a mix of userspace and kernelspace code.

Depends on #76 . Changes unique to this PR:

- Clarify what toolchains are used for each cargo/ directory in build/, ...