### PR TITLE
Tell cargo to not touch elf2tab's Cargo.lock

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Subdirectories containing Build.mk files.
-BUILD_SUBDIRS := golf2 third_party userspace
+BUILD_SUBDIRS := golf2 runner third_party userspace
 
 .PHONY: all
 all: build

--- a/doc/build_system.md
+++ b/doc/build_system.md
@@ -76,17 +76,20 @@ directory structure of `build/`:
 
 ```
 build/
-    cargo-host/         # Cargo-managed artifacts for the host machine
+    cargo-host/         # Cargo-managed artifacts for the host machine. Uses
+                        # elf2tab's toolchain version.
     device_lock         # Lock file used with flock() to prevent concurrent uses
                         # of the device.
     userspace/
-        cargo/          # userspace/ Cargo workspace target tree
+        cargo/          # userspace/ Cargo workspace target tree. Uses
+                        # libtock-rs's toolchain version.
         h1b_tests/      # Non-cargo-managed files specific to h1b_tests
         u2f_app/
         libgolf2/
         ...
     golf2/
         cargo/          # Cargo-managed artifacts for the golf2 Tock kernel.
+                        # Uses tock's toolchain version.
         ...
     third_party/
         chromiumos-ec/  # chromiumos-ec library artifacts.

--- a/doc/build_system.md
+++ b/doc/build_system.md
@@ -77,6 +77,8 @@ directory structure of `build/`:
 ```
 build/
     cargo-host/         # Cargo-managed artifacts for the host machine
+    device_lock         # Lock file used with flock() to prevent concurrent uses
+                        # of the device.
     userspace/
         cargo/          # userspace/ Cargo workspace target tree
         h1b_tests/      # Non-cargo-managed files specific to h1b_tests

--- a/golf2/rust-toolchain
+++ b/golf2/rust-toolchain
@@ -1,0 +1,1 @@
+../third_party/tock/rust-toolchain

--- a/runner/Build.mk
+++ b/runner/Build.mk
@@ -1,0 +1,41 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+.PHONY: runner/build
+runner/build: build/cargo-host/release/runner
+
+.PHONY: runner/check
+runner/check:
+	cd runner && \
+		CARGO_BUILD_TARGET_DIR="../build/cargo-host" cargo check
+
+.PHONY: runner/devicetests
+runner/devicetests:
+
+.PHONY: runner/doc
+runner/doc:
+	cd runner && \
+		CARGO_BUILD_TARGET_DIR="../build/cargo-host" cargo doc
+
+.PHONY: runner/localtests
+runner/localtests:
+	cd runner && \
+		CARGO_BUILD_TARGET_DIR="../build/cargo-host" cargo test
+
+
+.PHONY: build/cargo-host/release/runner
+build/cargo-host/release/runner:
+	cd runner && \
+		CARGO_BUILD_TARGET_DIR="../build/cargo-host" \
+		cargo build --release

--- a/runner/Cargo.toml
+++ b/runner/Cargo.toml
@@ -1,0 +1,24 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[package]
+name = "runner"
+version = "0.1.0"
+authors = ["jrvanwhy <jrvanwhy@google.com>"]
+edition = "2018"
+publish = false
+
+[dependencies]
+clap = { path = "../third_party/clap" }
+libc = { path = "../third_party/libc" }

--- a/runner/Makefile
+++ b/runner/Makefile
@@ -1,0 +1,17 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+INVOKE_DIR    := runner
+TOCK_ON_TITAN := ..
+include $(TOCK_ON_TITAN)/DirShim.mk

--- a/runner/rust-toolchain
+++ b/runner/rust-toolchain
@@ -1,0 +1,1 @@
+../third_party/elf2tab/rust-toolchain

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -1,0 +1,122 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Display the console output of the running h1b firmware. If --test is passed,
+// this will reset the h1b (to restart the running tests) and exit when the
+// tests are complete. If --test is passed, the return code indicates whether
+// the tests were successful. If --test is not passed, this always returns
+// success (even when interrupted); this allows it to be killed with an
+// interrupt signal without causing `make` to throw an error.
+//
+// Prior to running this, the /dev/ttyUltraConsole3 and /dev/ttyUltraTarget2
+// devices must be properly configured (115200 baud, echo off).
+
+// Because ending executing via Ctrl-C (SIGINT) is the expected behavior for
+// `make run`, we want to return 0 on SIGINT to minimize the error message from
+// `make` in that case. This signal handler simply terminates the process when
+// an interrupt is received, setting the exit code to 0.
+extern "C" fn sigint_handler(_: libc::c_int) {
+    unsafe { libc::_exit(0); }  // _exit() is signal-safe, exit() is not.
+}
+
+fn main() {
+    use std::io::{Read,Write};
+
+    let cmdline_matches = clap::App::new("runner")
+        .arg(clap::Arg::with_name("delay").help("Reset delay in milliseconds")
+             .long("delay").short("d").takes_value(true))
+        .arg(clap::Arg::with_name("test").long("test").short("t"))
+        .get_matches();
+
+    // Parse the command line arguments early so that we fail fast (with a nice
+    // error message) if we cannot parse them. This avoids resetting the H1B if
+    // a bad command line argument is used.
+    let delay = cmdline_matches.value_of("delay")
+        .map_or(100, |d| d.parse().expect("Unable to parse --delay value"));
+
+    // When this runner starts, the H1B will already be running. As a result, we
+    // may have missed some of its output. This is particularly problematic for
+    // --test, as we may have missed important markers.
+    //
+    // To collect as much of the H1B's output as possible, we perform the
+    // following sequence:
+    //   1. Power down the H1B (write "0").
+    //   2. Wait a bit (unfortunately we don't have a way to know for sure
+    //      whether the device is powered down). Flush the target's console
+    //      during/after the wait.
+    //   3. Start listening to the debug console output (this happens
+    //      implicitly).
+    //   4. Power up the H1B (write "1").
+    let mut debug_console = std::fs::OpenOptions::new()
+                            .append(true)
+                            .open("/dev/ttyUltraConsole3")
+                            .expect("Unable to open /dev/ttyUltraConsole3");
+    // 1. Power down the H1B
+    debug_console.write_all(b"0").expect("Unable to reset H1B (failed write)");
+    debug_console.flush().expect("Unable to reset H1B (failed flush)");
+
+    // 2. Wait for --delay milliseconds.
+    std::thread::sleep(std::time::Duration::from_millis(delay));
+
+    // 3. Open the console
+    let target_console = std::fs::OpenOptions::new()
+                         .read(true)
+                         .open("/dev/ttyUltraTarget2")
+                         .expect("Unable to open /dev/ttyUltraTarget2");
+
+    // 4. Power up the H1B.
+    debug_console.write_all(b"1").expect("Unable to restart H1B (failed write)");
+    debug_console.flush().expect("Unable to restart H1B (failed flush)");
+
+    // If we're not in --test mode, return 0 on SIGINT.
+    let test_mode = cmdline_matches.is_present("test");
+    if !test_mode {
+        unsafe { libc::signal(libc::SIGINT, sigint_handler as usize); }
+    }
+
+    // Stream in the console output, and echo it to stdout. If --test was
+    // passed, we search for \nTEST_FINISHED: [FAIL|SUCCESS]\n and terminate
+    // (with the corresponding error code) once found.
+    let fail_message = b"\nTEST_FINISHED: FAIL\n";
+    let success_message = b"\nTEST_FINISHED: SUCCESS\n";
+    // The buffer length needs to match the larger of fail_message and
+    // success_message.
+    let mut buffer = vec![0; std::cmp::max(fail_message.len(), success_message.len())];
+    for byte in target_console.bytes() {
+        let byte = byte.expect("Console read error");
+        std::io::stdout().write(&[byte]).expect("Failed to echo to stdout");
+
+        if test_mode {
+            // Rotate byte into the buffer (shifting the buffer contents 1 byte to
+            // the left and appending byte).
+            for i in 1..buffer.len() { buffer[i-1] = buffer[i]; }
+            *buffer.last_mut().expect("empty buffer") = byte;
+
+            if &buffer[success_message.len()-fail_message.len()..] == fail_message {
+                // Return 3 to match Bazel's behavior (build successful but tests
+                // failed).
+                std::process::exit(3);
+            }
+
+            if &buffer == success_message {
+                return;
+            }
+        }
+    }
+
+    // Unexpected: we received EOF but tests did not finish. Return 6 (Bazel's
+    // "run failure" error message).
+    println!("\nUnexpected EOF from target console.");
+    std::process::exit(6);
+}

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,0 @@
-third_party/tock/rust-toolchain

--- a/third_party/Build.mk
+++ b/third_party/Build.mk
@@ -26,7 +26,7 @@ third_party/build: build/cargo-host/release/elf2tab
 .PHONY: third_party/check
 third_party/check:
 	cd third_party/elf2tab && \
-		CARGO_BUILD_TARGET_DIR="../../build/cargo-host" cargo check
+		CARGO_BUILD_TARGET_DIR="../../build/cargo-host" cargo check --frozen
 
 .PHONY: third_party/devicetests
 third_party/devicetests:
@@ -34,16 +34,16 @@ third_party/devicetests:
 .PHONY: third_party/doc
 third_party/doc:
 	cd third_party/elf2tab && \
-		CARGO_BUILD_TARGET_DIR="../../build/cargo-host" cargo doc
+		CARGO_BUILD_TARGET_DIR="../../build/cargo-host" cargo doc --frozen
 
 .PHONY: third_party/localtests
 third_party/localtests:
 	cd third_party/elf2tab && \
-		CARGO_BUILD_TARGET_DIR="../../build/cargo-host" cargo test
+		CARGO_BUILD_TARGET_DIR="../../build/cargo-host" cargo test --frozen
 
 
 .PHONY: build/cargo-host/release/elf2tab
 build/cargo-host/release/elf2tab:
 	cd third_party/elf2tab && \
 		CARGO_BUILD_TARGET_DIR="../../build/cargo-host" \
-		cargo build --release
+		cargo build --frozen --release

--- a/userspace/Build.mk
+++ b/userspace/Build.mk
@@ -75,10 +75,15 @@ $(foreach APP,$(C_APPS),userspace/$(APP)/program): userspace/%/program: \
 	flock build/device_lock $(TANGO_SPIFLASH) --verbose \
 		--input=build/userspace/$*/full_image
 
-# TODO: Write a program to display the console output and call it here.
-.PHONY: $(foreach APP,$(C_APPS),userspace/$(APP)/program)
+.PHONY: $(foreach APP,$(C_APPS),userspace/$(APP)/run)
 $(foreach APP,$(C_APPS),userspace/$(APP)/run): userspace/%/run: \
-		userspace/%/program
+		build/cargo-host/release/runner build/userspace/%/full_image
+	flock build/device_lock -c ' \
+		$(TANGO_SPIFLASH) --verbose \
+			--input=build/userspace/$*/full_image ; \
+		stty -F /dev/ttyUltraConsole3 115200 -echo ; \
+		stty -F /dev/ttyUltraTarget2 115200 -icrnl ; \
+		build/cargo-host/release/runner'
 
 .PHONY: $(foreach APP,$(C_APPS),build/userspace/$(APP)/cortex-m3/cortex-m3.tbf)
 $(foreach APP,$(C_APPS),build/userspace/$(APP)/cortex-m3/cortex-m3.tbf): \

--- a/userspace/Build.mk
+++ b/userspace/Build.mk
@@ -72,7 +72,8 @@ $(foreach APP,$(C_APPS),userspace/$(APP)/localtests):
 .PHONY: $(foreach APP,$(C_APPS),userspace/$(APP)/program)
 $(foreach APP,$(C_APPS),userspace/$(APP)/program): userspace/%/program: \
 		build/userspace/%/full_image
-	$(TANGO_SPIFLASH) --verbose --input=build/userspace/$*/full_image
+	flock build/device_lock $(TANGO_SPIFLASH) --verbose \
+		--input=build/userspace/$*/full_image
 
 # TODO: Write a program to display the console output and call it here.
 .PHONY: $(foreach APP,$(C_APPS),userspace/$(APP)/program)

--- a/userspace/h1b_tests/Build.mk
+++ b/userspace/h1b_tests/Build.mk
@@ -32,7 +32,8 @@ userspace/h1b_tests/localtests:
 
 .PHONY: userspace/h1b_tests/program
 userspace/h1b_tests/program: build/userspace/h1b_tests/full_image
-	$(TANGO_SPIFLASH) --verbose --input=build/userspace/h1b_tests/full_image
+	flock build/device_lock $(TANGO_SPIFLASH) --verbose \
+		--input=build/userspace/h1b_tests/full_image
 
 # TODO: Implement a runner.
 .PHONY: userspace/h1b_tests/run

--- a/userspace/h1b_tests/src/lib.rs
+++ b/userspace/h1b_tests/src/lib.rs
@@ -19,6 +19,6 @@ fn basic_test() -> bool {
     use core::fmt::Write;
     let _ = writeln!(libtock::console::Console::new(),
                      "Cat video count: {}\nWhat we eat: {:x}", 9001, 3405705229u32);
-    libtock::timer::sleep(libtock::timer::Duration::from_ms(1000));
+    libtock::timer::sleep(libtock::timer::Duration::from_ms(100));
     true
 }

--- a/userspace/test_harness/src/lib.rs
+++ b/userspace/test_harness/src/lib.rs
@@ -97,6 +97,6 @@ pub fn test_main_static(tests: &[&TestDescAndFn]) {
                          if succeeded { "succeeded" } else { "failed" });
         overall_success &= succeeded;
     }
-    let _ = writeln!(console, "Testing complete. Result: {}",
-           if overall_success { "succeeded" } else { "failed" });
+    let _ = writeln!(console, "TEST_FINISHED: {}",
+           if overall_success { "SUCCESS" } else { "FAIL" });
 }


### PR DESCRIPTION
Recent changes to cargo make it want to add a comment to Cargo.lock that is not in upstream elf2tab. Tell cargo not to touch it (it's an input not an output).

Depends on #79. Commits unique to this PR:

1. Tell Cargo not to modify the Cargo.lock in elf2tab.

```
--------------
PR test state:
--------------
git rev-parse HEAD
c93e506cc1b50b70db2c0c211da3a3fcb9d78daa
git status
On branch freeze-elf2tab
Your branch is up to date with 'origin/freeze-elf2tab'.

nothing to commit, working tree clean
make[1]: Leaving directory '/usr/local/google/home/jrvanwhy/tock-on-titan'
```