### PR TITLE
Add traits used by the flash driver: Client and HwInterface.

### DIFF
--- a/h1b/Cargo.toml
+++ b/h1b/Cargo.toml
@@ -23,3 +23,7 @@ build = "build.rs"
 kernel = { path = "../third_party/tock/kernel" }
 cortexm3 = { path = "../third_party/tock/arch/cortex-m3" }
 
+[features]
+# Exports testing-specific features for use by h1b_tests. Should not be enabled
+# when compiled for the kernel.
+test = []

--- a/h1b/src/hil/flash/driver.rs
+++ b/h1b/src/hil/flash/driver.rs
@@ -1,0 +1,20 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// A client of the Flash driver -- receives callbacks when flash operations
+/// complete.
+pub trait Client {
+    fn erase_done(&self, kernel::ReturnCode);
+    fn write_done(&self, kernel::ReturnCode);
+}

--- a/h1b/src/hil/flash/hardware.rs
+++ b/h1b/src/hil/flash/hardware.rs
@@ -1,0 +1,48 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// The interface between the flash driver and the (real or fake) flash module.
+
+pub trait Hardware<'a> {
+	/// Returns true if an operation is running, false otherwise.
+	fn is_programming(&self) -> bool;
+
+	/// Read a single word from the flash (non-blocking). offset is in units of
+	/// words and is relative to the start of flash.
+	fn read(&self, offset: usize) -> u32;
+
+	/// Reads the flash error code.
+	fn read_error(&self) -> u16;
+
+	/// Sets the client (the job receiving interrupts from the underlying
+	/// hardware).
+	fn set_client(&self, client: &'a Client);
+
+	/// Set flash transaction parameters (word offset and size). The word offset
+	/// is relative to the start of flash and the size is one less than the
+	/// number of words to copy.
+	fn set_transaction(&self, offset: usize, size: usize);
+
+	/// Fill the flash controller's write buffer. data must have a length no
+	/// larger than 32.
+	fn set_write_data(&self, data: &[u32]);
+
+	/// Kick off a smart program execution.
+	fn trigger(&self, opcode: u32);
+}
+
+trait Client {
+	/// Called when a flash programming operation completes.
+	fn interrupt(&self);
+}

--- a/h1b/src/hil/flash/mod.rs
+++ b/h1b/src/hil/flash/mod.rs
@@ -1,0 +1,23 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Flash driver for H1B. Implements the Tock flash HIL trait as well as an API
+// more representative of the H1B flash hardware's capabilities (e.g. sub-page
+// writes and counters).
+
+mod driver;
+mod hardware;
+
+pub use self::driver::Client;
+pub use self::hardware::Hardware;

--- a/userspace/h1b_tests/Build.mk
+++ b/userspace/h1b_tests/Build.mk
@@ -17,7 +17,8 @@ userspace/h1b_tests/build: build/userspace/h1b_tests/full_image
 
 .PHONY: userspace/h1b_tests/check
 userspace/h1b_tests/check:
-	cd userspace/h1b_tests && cargo check --release -Z offline
+	cd userspace/h1b_tests && TOCK_KERNEL_VERSION=h1b_tests cargo check \
+		--release -Z offline
 
 .PHONY: userspace/h1b_tests/devicetests
 userspace/h1b_tests/devicetests: build/cargo-host/release/runner \

--- a/userspace/h1b_tests/Cargo.toml
+++ b/userspace/h1b_tests/Cargo.toml
@@ -20,6 +20,8 @@ edition = "2018"
 publish = false
 
 [dependencies]
+h1b = { features = ["test"], path = "../../h1b" }
+kernel = { path = "../../third_party/tock/kernel" }
 libtock = { path = "../../third_party/libtock-rs" }
 
 [dev-dependencies]


### PR DESCRIPTION
Client contains callbacks executed when the driver finishes an operation. HwInterface is the interface between the flash driver and the underlying hardware; it is abstracted into a trait so that we can fake the flash hardware out during unit testing.

Commits new to this PR:

1. Add traits used by the flash driver: Client and HwInterface.

```
----------------------
`make prtest` summary:
----------------------
git rev-parse HEAD
24c7b5625638bed4c1e50f2a826ba9b0c4b57435
git status
On branch driver-traits
nothing to commit, working tree clean
```