### PR TITLE
Add a state machine for asynchronously driving the flash controller's smart programming functionality.

### DIFF
--- a/h1b/Cargo.toml
+++ b/h1b/Cargo.toml
@@ -23,3 +23,7 @@ build = "build.rs"
 kernel = { path = "../third_party/tock/kernel" }
 cortexm3 = { path = "../third_party/tock/arch/cortex-m3" }
 
+[features]
+# Exports testing-specific features for use by h1b_tests. Should not be enabled
+# when compiled for the kernel.
+test = []

--- a/h1b/src/hil/flash/driver.rs
+++ b/h1b/src/hil/flash/driver.rs
@@ -1,0 +1,20 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// A client of the Flash driver -- receives callbacks when flash operations
+/// complete.
+pub trait Client {
+    fn erase_done(&self, kernel::ReturnCode);
+    fn write_done(&self, kernel::ReturnCode);
+}

--- a/h1b/src/hil/flash/fake.rs
+++ b/h1b/src/hil/flash/fake.rs
@@ -1,0 +1,138 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[derive(Clone,Copy,Default)]
+struct LogEntry {
+    /// The value of the operation. u32::MAX indicates this was an erase,
+    /// otherwise it was a write.
+    value: u32,
+
+    /// The operation's offset. This is in units of words from the start of
+    /// flash.
+    offset: usize,
+}
+
+/// A fake version of H1B's flash modules. Starts initialized with all 1's as if
+/// the flash had just been erased. To keep memory usage small, this supports a
+/// limited number of operations before panicking.
+pub struct FakeHw<'a> {
+    client: core::cell::Cell<Option<&'a super::hardware::Client>>,
+    error: core::cell::Cell<u16>,
+    // Currently-executing opcode; 0 if no transaction is ongoing.
+    opcode: core::cell::Cell<u32>,
+
+    transaction_offset: core::cell::Cell<usize>,
+    transaction_size: core::cell::Cell<usize>,
+    write_data: [core::cell::Cell<u32>; 32],
+
+    // Changes that have been successfully applied to the flash. Replayed during
+    // simulated reads to determine the value of a cell.
+    log: [core::cell::Cell<LogEntry>; 5],
+    log_len: core::cell::Cell<usize>,
+}
+
+impl<'a> FakeHw<'a> {
+    pub fn new() -> Self {
+        Self {
+            client:             Default::default(),
+            error:              Default::default(),
+            opcode:             Default::default(),
+            transaction_offset: Default::default(),
+            transaction_size:   Default::default(),
+            write_data:         Default::default(),
+            log:                Default::default(),
+            log_len:            Default::default(),
+        }
+    }
+
+    /// Simulates the flash module successfully finishing an operation.
+    pub fn finish_operation(&self) {
+        if self.opcode.get() == 0x31415927 {
+            // An erase is recorded as a single log entry.
+            self.transaction_size.set(1);
+        }
+
+        for i in 0..self.transaction_size.get() {
+            self.log[self.log_len.get()].set(LogEntry {
+                value:
+                    if self.opcode.get() == 0x31415927 {
+                        core::u32::MAX
+                    } else {
+                        self.write_data[i].get()
+                    },
+                offset: self.transaction_offset.get() + i,
+            });
+            self.log_len.set(self.log_len.get() + 1);
+        }
+        self.opcode.set(0);
+        if let Some(client) = self.client.get() { client.interrupt(); }
+    }
+
+    /// Simulates a flash error.
+    pub fn inject_error(&self, error: u16) {
+        self.error.set(error);
+        self.opcode.set(0);
+        if let Some(client) = self.client.get() { client.interrupt(); }
+    }
+}
+
+impl<'a> super::hardware::Hardware<'a> for FakeHw<'a> {
+    fn is_programming(&self) -> bool {
+        self.opcode.get() != 0
+    }
+
+    fn read(&self, offset: usize) -> u32 {
+        // Pretend that flash was initialized to all ones.
+        let mut value = 0xFFFFFFFF;
+        // Replay the operation log to find the current value.
+        for entry in self.log[0..self.log_len.get()].iter().map(|e| e.get()) {
+            if entry.value == core::u32::MAX {
+                // Erase
+                if offset >= entry.offset && offset < entry.offset + 512 {
+                    value = core::u32::MAX;
+                }
+            } else {
+                // Write
+                if offset == entry.offset {
+                    value &= entry.value;
+                }
+            }
+        }
+        value
+    }
+
+    fn read_error(&self) -> u16 {
+        // The error register is self-clearing.
+        let out = self.error.get();
+        self.error.set(0);
+        out
+    }
+
+    fn set_client(&self, client: &'a super::hardware::Client) {
+        self.client.set(Some(client));
+    }
+
+    fn set_transaction(&self, offset: usize, size: usize) {
+        self.transaction_offset.set(offset);
+        self.transaction_size.set(size + 1);
+    }
+
+    fn set_write_data(&self, data: &[u32]) {
+        for (i, &v) in data.iter().enumerate() { self.write_data[i].set(v); }
+    }
+
+    fn trigger(&self, opcode: u32) {
+        self.opcode.set(opcode);
+    }
+}

--- a/h1b/src/hil/flash/h1b_hw.rs
+++ b/h1b/src/hil/flash/h1b_hw.rs
@@ -1,0 +1,273 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use kernel::common::cells::VolatileCell;
+use kernel::common::registers::ReadWrite;
+
+// We're relying on the fact that Tock is single-threaded for thread safety.
+static mut CLIENT: Option<&'static super::hardware::Client> = None;
+
+register_bitfields![u32,
+	TransactionParameters [
+		Offset OFFSET(0) NUMBITS(16) [],
+		Bank   OFFSET(16) NUMBITS(1) [],
+		Size   OFFSET(17) NUMBITS(5) []
+	]
+];
+
+#[repr(C)]
+pub struct H1bHw {
+	/// Read/Program/Erase control for flash macro 0.
+	pe_control_0: VolatileCell<u32>,
+
+	/// Read/Program/Erase control for flash macro 1.
+	pe_control_1: VolatileCell<u32>,
+
+	/// Write size and offset.
+	transaction_parameters: ReadWrite<u32, TransactionParameters::Register>,
+
+	/// Read/erase/program lockdown modes for the various flash regions.
+	lockdown_triggers: VolatileCell<u32>,
+
+	/// Triggers a read of info 0 data to check for secure data write functionality. Only available
+	/// in test mode.
+	_enable_info0_shadow_read: VolatileCell<u32>,
+
+	/// Operation-completion interrupt controls.
+	interrupt_control: VolatileCell<u32>,
+
+	/// Operation-completion state. Cleared on read.
+	interrupt_state: VolatileCell<u32>,
+
+	/// Macro 0 override signal unlock.
+	_override_0_unlock: VolatileCell<u32>,
+
+	/// Macro 1 override signal unlock.
+	_override_1_unlock: VolatileCell<u32>,
+
+	/// DIN override.
+	_din_override: VolatileCell<u32>,
+
+	/// Offset override.
+	_offset_override: VolatileCell<u32>,
+
+	/// Signal override values.
+	_override_signal_values: VolatileCell<u32>,
+
+	/// Signal override controls.
+	_override_signal_control: VolatileCell<u32>,
+
+	/// Controls whether the system may powerdown without waiting for graceful brownout completion.
+	disable_brownout_wait: VolatileCell<u32>,
+
+	/// The most recent value of Macro 0's DOUT.
+	dout_value_0: VolatileCell<u32>,
+
+	/// TC override read value.
+	_tc_override_value_0: VolatileCell<u32>,
+
+	/// The most recent value of Macro 1's DOUT.
+	dout_value_1: VolatileCell<u32>,
+
+	/// TC override read value.
+	_tc_override_value_1: VolatileCell<u32>,
+
+	/// Write data buffer.
+	write_data: [VolatileCell<u32>; 32],
+
+	/// Program and erase enable.
+	program_erase_enable: VolatileCell<u32>,
+
+	/// Redundancy remapping enablement and control for macro 0.
+	redundancy_remapping_0: VolatileCell<u32>,
+
+	/// Redundancy remapping enablement and control for macro 1.
+	redundancy_remapping_1: VolatileCell<u32>,
+
+	/// Error signalling.
+	error_code: VolatileCell<u32>,
+
+	/// Read operation duration.
+	read_cycles: VolatileCell<u32>,
+
+	/// The first cycle XE should be asserted during reads.
+	read_xe_first_cycle: VolatileCell<u32>,
+
+	/// The last cycle XE should be asserted during reads.
+	read_xe_last_cycle: VolatileCell<u32>,
+
+	/// The first cycle YE should be asserted during reads.
+	read_ye_first_cycle: VolatileCell<u32>,
+
+	/// The last cycle YE should be asserted during reads.
+	read_ye_last_cycle: VolatileCell<u32>,
+
+	/// The first cycle SE should be asserted during reads.
+	read_se_first_cycle: VolatileCell<u32>,
+
+	/// The last cycle SE should be asserted during reads.
+	read_se_last_cycle: VolatileCell<u32>,
+
+	/// The first cycle PV should be asserted during program verify reads.
+	read_pv_first_cycle: VolatileCell<u32>,
+
+	/// The last cycle PV should be asserted during program verify reads.
+	read_pv_last_cycle: VolatileCell<u32>,
+
+	/// The first cycle EV should be asserted during erase verify reads.
+	read_ev_first_cycle: VolatileCell<u32>,
+
+	/// The last cycle EV should be asserted during erase verify reads.
+	read_ev_last_cycle: VolatileCell<u32>,
+
+	/// Smart program algorithm enablement.
+	enable_smart_program: VolatileCell<u32>,
+
+	/// Single-word program timing.
+	program_cycles: VolatileCell<u32>,
+
+	/// The first cycle XE should be asserted during program.
+	program_xe_first_cycle: VolatileCell<u32>,
+
+	/// The last cycle XE should be asserted during program.
+	program_xe_last_cycle: VolatileCell<u32>,
+
+	/// The first cycle YE should be asserted during program.
+	program_ye_first_cycle: VolatileCell<u32>,
+
+	/// The last cycle YE should be asserted during program.
+	program_ye_last_cycle: VolatileCell<u32>,
+
+	/// The first cycle DIN and YADR are ready during program.
+	program_din_yadr_first_cycle: VolatileCell<u32>,
+
+	/// The last cycle DIN and YADR are ready during program.
+	program_din_yadr_last_cycle: VolatileCell<u32>,
+
+	/// The first cycle PROG should be asserted during program.
+	program_prog_first_cycle: VolatileCell<u32>,
+
+	/// The last cycle PROG should be asserted during program.
+	program_prog_last_cycle: VolatileCell<u32>,
+
+	/// The first cycle NVSTR should be asserted during program.
+	program_nvstr_first_cycle: VolatileCell<u32>,
+
+	/// The last cycle NVSTR should be asserted during program.
+	program_nvstr_last_cycle: VolatileCell<u32>,
+
+	/// Smart erase algorithm enablement.
+	enable_smart_erase: VolatileCell<u32>,
+
+	/// Flash erase cycle count.
+	erase_cycles: VolatileCell<u32>,
+
+	/// The first cycle XE should be asserted during erase.
+	erase_xe_first_cycle: VolatileCell<u32>,
+
+	/// The last cycle XE should be asserted during erase.
+	erase_xe_last_cycle: VolatileCell<u32>,
+
+	/// The first cycle ERASE should be asserted during erase.
+	erase_erase_first_cycle: VolatileCell<u32>,
+
+	/// The last cycle ERASE should be asserted during erase.
+	erase_erase_last_cycle: VolatileCell<u32>,
+
+	/// The first cycle NVSTR should be asserted during erase.
+	erase_nvstr_first_cycle: VolatileCell<u32>,
+
+	/// The last cycle NVSTR should be asserted during erase.
+	erase_nvstr_last_cycle: VolatileCell<u32>,
+
+	/// Enable smart erase for bulk erases.
+	enable_bulk_smart_erase: VolatileCell<u32>,
+
+	/// Duration of bulk erase operations.
+	bulk_erase_cycles: VolatileCell<u32>,
+
+	/// The first cycle XE should be asserted during bulkerase.
+	bulkerase_xe_first_cycle: VolatileCell<u32>,
+
+	/// The last cycle XE should be asserted during bulkerase.
+	bulkerase_xe_last_cycle: VolatileCell<u32>,
+
+	/// The first cycle BULKERASE should be asserted during bulkerase.
+	bulkerase_bulkerase_first_cycle: VolatileCell<u32>,
+
+	/// The last cycle BULKERASE should be asserted during bulkerase.
+	bulkerase_bulkerase_last_cycle: VolatileCell<u32>,
+
+	/// The first cycle MAS1 should be asserted during bulkerase.
+	bulkerase_mas1_first_cycle: VolatileCell<u32>,
+
+	/// The last cycle MAS1 should be asserted during bulkerase.
+	bulkerase_mas1_last_cycle: VolatileCell<u32>,
+
+	/// The first cycle NVSTR should be asserted during bulkerase.
+	bulkerase_nvstr_first_cycle: VolatileCell<u32>,
+
+	/// The last cycle NVSTR should be asserted during bulkerase.
+	bulkerase_nvstr_last_cycle: VolatileCell<u32>,
+
+	/// Controller debug signals.
+	debug_signals: VolatileCell<u32>,
+
+	// The integration test controls are omitted because they are unnecessary
+	// and are after a large address space gap.
+}
+
+impl H1bHw {
+	/// Should be called when the flash's program interrupt fires.
+	pub fn program_interrupt(&self) {
+		if let Some(client) = unsafe { CLIENT } { client.interrupt(); }
+	}
+}
+
+impl super::hardware::Hardware<'static> for H1bHw {
+	fn is_programming(&self) -> bool {
+		// TODO(jrvanwhy): Only checks the second flash bank.
+		self.pe_control_1.get() != 0
+	}
+
+	fn read(&self, offset: usize) -> u32 {
+		// The two flash macros are in consecutive memory locations, so they can
+		// be addressed as one.
+		unsafe { ::core::ptr::read_volatile((0x40000 as *const u32).add(offset)) }
+	}
+
+	fn read_error(&self) -> u16 {
+		self.error_code.get() as u16
+	}
+
+	fn set_client(&self, client: &'static super::hardware::Client) {
+		unsafe { CLIENT = Some(client); }
+	}
+
+	fn set_transaction(&self, offset: usize, size: usize) {
+		use self::TransactionParameters::{Offset,Size};
+		self.transaction_parameters.write(Offset.val(offset as u32) + Size.val(size as u32));
+	}
+
+	fn set_write_data(&self, data: &[u32]) {
+		for (i, &v) in data.iter().enumerate() { self.write_data[i].set(v); }
+	}
+
+	fn trigger(&self, opcode: u32) {
+		self.program_erase_enable.set(0xb11924e1);
+		// TODO(jrvanwhy): Assumes the write is to the second flash bank (where
+		// the nvmem counter is).
+		self.pe_control_1.set(opcode);
+	}
+}

--- a/h1b/src/hil/flash/hardware.rs
+++ b/h1b/src/hil/flash/hardware.rs
@@ -42,7 +42,7 @@ pub trait Hardware<'a> {
 	fn trigger(&self, opcode: u32);
 }
 
-trait Client {
+pub trait Client {
 	/// Called when a flash programming operation completes.
 	fn interrupt(&self);
 }

--- a/h1b/src/hil/flash/hardware.rs
+++ b/h1b/src/hil/flash/hardware.rs
@@ -1,0 +1,48 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// The interface between the flash driver and the (real or fake) flash module.
+
+pub trait Hardware<'a> {
+	/// Returns true if an operation is running, false otherwise.
+	fn is_programming(&self) -> bool;
+
+	/// Read a single word from the flash (non-blocking). offset is in units of
+	/// words and is relative to the start of flash.
+	fn read(&self, offset: usize) -> u32;
+
+	/// Reads the flash error code.
+	fn read_error(&self) -> u16;
+
+	/// Sets the client (the job receiving interrupts from the underlying
+	/// hardware).
+	fn set_client(&self, client: &'a Client);
+
+	/// Set flash transaction parameters (word offset and size). The word offset
+	/// is relative to the start of flash and the size is one less than the
+	/// number of words to copy.
+	fn set_transaction(&self, offset: usize, size: usize);
+
+	/// Fill the flash controller's write buffer. data must have a length no
+	/// larger than 32.
+	fn set_write_data(&self, data: &[u32]);
+
+	/// Kick off a smart program execution.
+	fn trigger(&self, opcode: u32);
+}
+
+trait Client {
+	/// Called when a flash programming operation completes.
+	fn interrupt(&self);
+}

--- a/h1b/src/hil/flash/mod.rs
+++ b/h1b/src/hil/flash/mod.rs
@@ -1,0 +1,23 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Flash driver for H1B. Implements the Tock flash HIL trait as well as an API
+// more representative of the H1B flash hardware's capabilities (e.g. sub-page
+// writes and counters).
+
+mod driver;
+mod hardware;
+
+pub use self::driver::Client;
+pub use self::hardware::Hardware;

--- a/h1b/src/hil/flash/mod.rs
+++ b/h1b/src/hil/flash/mod.rs
@@ -19,6 +19,7 @@
 mod driver;
 #[cfg(feature = "test")]
 pub mod fake;
+pub mod h1b_hw;
 mod hardware;
 
 pub use self::driver::Client;

--- a/h1b/src/hil/flash/mod.rs
+++ b/h1b/src/hil/flash/mod.rs
@@ -17,6 +17,8 @@
 // writes and counters).
 
 mod driver;
+#[cfg(feature = "test")]
+pub mod fake;
 mod hardware;
 
 pub use self::driver::Client;

--- a/h1b/src/hil/flash/mod.rs
+++ b/h1b/src/hil/flash/mod.rs
@@ -21,6 +21,7 @@ mod driver;
 pub mod fake;
 pub mod h1b_hw;
 mod hardware;
+pub mod smart_program;
 
 pub use self::driver::Client;
 pub use self::hardware::Hardware;

--- a/h1b/src/hil/flash/smart_program.rs
+++ b/h1b/src/hil/flash/smart_program.rs
@@ -1,0 +1,115 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// A state machine for driving execution of the flash module's smart
+/// programming functionality.
+
+use ::kernel::hil::time::{Alarm,Frequency};
+use ::kernel::ReturnCode;
+
+pub enum SmartProgramState {
+	Init(/*attempts_remaining*/ u8),
+	Running(/*attempts_remaining*/ u8),
+	Finished(/*return_code*/ ReturnCode),
+}
+
+use self::SmartProgramState::{Init,Finished,Running};
+
+impl SmartProgramState {
+	/// Initialize the smart programming state machine. The state machine must
+	/// be stepped before it will do anything.
+	pub fn init(max_attempts: u8) -> Self {
+		Init(max_attempts)
+	}
+
+	/// Returns the return code for the smart program execution, or None if it
+	/// is still running.
+	pub fn return_code(&self) -> Option<ReturnCode> {
+		if let Finished(code) = *self { Some(code) } else { None }
+	}
+
+	/// Performs a state machine update during smart programming. This should be
+	/// done during initialization, after an interrupt, and when a timeout
+	/// expires.
+	pub fn step<'h, A: Alarm, H: super::hardware::Hardware<'h>>(
+		self, alarm: &A, hw: &H, opcode: u32, is_timeout: bool) -> Self
+	{
+		match self {
+			Init(attempts_remaining) => {
+				hw.trigger(opcode);
+				set_program_timeout(alarm);
+				Running(attempts_remaining - 1)
+			},
+			Running(attempts_remaining) => {
+				// Copied from Cr50: a timeout causes an immediate failure with
+				// no retry.
+				if is_timeout {
+					alarm.disable();
+					return Finished(ReturnCode::FAIL);
+				}
+
+				// If this was a spurious interrupt, ignore it.
+				if hw.is_programming() { return Running(attempts_remaining); }
+
+				// Check for a successful operation.
+				let error = hw.read_error();
+				if error == 0 {
+					alarm.disable();
+					return Finished(ReturnCode::SUCCESS);
+				}
+
+				// This programming attempt failed; retry if we haven't hit the
+				// limit.
+				if attempts_remaining > 0 {
+					// Operation failed; retry.
+					hw.trigger(opcode);
+					set_program_timeout(alarm);
+					return SmartProgramState::Running(attempts_remaining - 1);
+				}
+
+				// The operation failed max_attempts times -- indicate an error.
+				alarm.disable();
+				return SmartProgramState::Finished(decode_error(error));
+			},
+			Finished(return_code) => Finished(return_code),
+		}
+	}
+}
+
+/// Converts the given flash error flag value into a Tock kernel return code.
+/// Assumes that error_flags is nonzero (e.g. that it represents a valid error).
+pub fn decode_error(error_flags: u16) -> ReturnCode {
+	// If the "out of main range" bit (0b10) is set, then the target location
+	// was probably out of bounds. Otherwise, emit a generic error message (none
+	// of the other error messages indicate anything other than driver or
+	// hardware errors).
+	if error_flags & 0b10 != 0 { ReturnCode::ESIZE } else { ReturnCode::FAIL }
+}
+
+// Divide two u32's while rounding up (rather than the default round-down
+// behavior).
+pub fn div_round_up(numerator: u32, denominator: u32) -> u32 {
+	numerator / denominator + if numerator % denominator == 0 { 0 } else { 1 }
+}
+
+// Sets an alarm for 150ms in the future. 150ms comes from the Cr50 source code
+// ({1} at the bottom of this file).
+fn set_program_timeout<A: Alarm>(alarm: &A) {
+	// 150ms is 3/20th of a second.
+	alarm.set_alarm(alarm.now() + div_round_up(A::Frequency::frequency() * 3, 20));
+}
+
+// Links that are too long to inline:
+//
+// {1} https://chromium.googlesource.com/chromiumos/platform/ec/+/8a411be5297f9886e6ee8bf1fdac7fe6b7e53667/chip/g/flash.c#242

--- a/h1b/src/hil/mod.rs
+++ b/h1b/src/hil/mod.rs
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub mod aes;
 pub mod common;
 pub mod digest;
-pub mod aes;
+pub mod flash;
 pub mod rng;

--- a/h1b/src/lib.rs
+++ b/h1b/src/lib.rs
@@ -15,8 +15,7 @@
 #![crate_name = "h1b"]
 #![crate_type = "rlib"]
 #![no_std]
-#![feature(asm, core_intrinsics, const_fn)]
-#![feature(attr_literals, naked_functions)]
+#![feature(asm, core_intrinsics, const_fn, naked_functions)]
 
 extern crate cortexm3;
 

--- a/userspace/h1b_tests/Build.mk
+++ b/userspace/h1b_tests/Build.mk
@@ -32,7 +32,8 @@ userspace/h1b_tests/devicetests: build/cargo-host/release/runner \
 
 .PHONY: userspace/h1b_tests/doc
 userspace/h1b_tests/doc:
-	cd userspace/h1b_tests && cargo doc --release -Z offline
+	cd userspace/h1b_tests && TOCK_KERNEL_VERSION=h1b_tests cargo doc \
+		--release -Z offline
 
 .PHONY: userspace/h1b_tests/localtests
 userspace/h1b_tests/localtests:

--- a/userspace/h1b_tests/Build.mk
+++ b/userspace/h1b_tests/Build.mk
@@ -17,7 +17,8 @@ userspace/h1b_tests/build: build/userspace/h1b_tests/full_image
 
 .PHONY: userspace/h1b_tests/check
 userspace/h1b_tests/check:
-	cd userspace/h1b_tests && cargo check --release -Z offline
+	cd userspace/h1b_tests && TOCK_KERNEL_VERSION=h1b_tests cargo check \
+		--release -Z offline
 
 .PHONY: userspace/h1b_tests/devicetests
 userspace/h1b_tests/devicetests: build/cargo-host/release/runner \

--- a/userspace/h1b_tests/Cargo.toml
+++ b/userspace/h1b_tests/Cargo.toml
@@ -20,6 +20,8 @@ edition = "2018"
 publish = false
 
 [dependencies]
+h1b = { features = ["test"], path = "../../h1b" }
+kernel = { path = "../../third_party/tock/kernel" }
 libtock = { path = "../../third_party/libtock-rs" }
 
 [dev-dependencies]

--- a/userspace/h1b_tests/src/hil/flash/fake.rs
+++ b/userspace/h1b_tests/src/hil/flash/fake.rs
@@ -1,0 +1,98 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// Works the fake through a series of writes and erases to test its
+/// functionality. Simulates both failed operations and successful operations.
+#[test]
+fn fake_hw() -> bool {
+	use { h1b::hil::flash::Hardware, test::require };
+	let fake = h1b::hil::flash::fake::FakeHw::new();
+
+	// Verify the initial state of the flash.
+	require!(fake.is_programming() == false);
+	require!(fake.read(512) == 0xFFFFFFFF);
+	require!(fake.read(1023) == 0xFFFFFFFF);
+	require!(fake.read(1300) == 0xFFFFFFFF);
+	require!(fake.read(1301) == 0xFFFFFFFF);
+
+	// Operation 1: successful write to two words.
+	fake.set_transaction(1300, 2 - 1);
+	fake.set_write_data(&[0xFFFF0FFF, 0xFFFAFFFF]);
+	fake.trigger(0x27182818);
+	require!(fake.is_programming() == true);
+	fake.finish_operation();
+	require!(fake.read_error() == 0);
+	require!(fake.is_programming() == false);
+	require!(fake.read(512) == 0xFFFFFFFF);
+	require!(fake.read(1023) == 0xFFFFFFFF);
+	require!(fake.read(1300) == 0xFFFF0FFF);
+	require!(fake.read(1301) == 0xFFFAFFFF);
+
+	// Operation 2: failed write. Verifies the write doesn't change anything.
+	fake.set_transaction(1300, 2 - 1);
+	fake.set_write_data(&[0xFFFF00FF, 0xFFAAFFFF]);
+	fake.trigger(0x27182818);
+	require!(fake.is_programming() == true);
+	fake.inject_error(0x8);  // Program failed
+	require!(fake.read_error() == 0x8);
+	require!(fake.is_programming() == false);
+	require!(fake.read(512) == 0xFFFFFFFF);
+	require!(fake.read(1023) == 0xFFFFFFFF);
+	require!(fake.read(1300) == 0xFFFF0FFF);
+	require!(fake.read(1301) == 0xFFFAFFFF);
+
+	// Operation 3: successful write to one word. Verifies the write doesn't
+	// overlap to the next word.
+	fake.set_transaction(1300, 1 - 1);
+	fake.set_write_data(&[0xFFFFC0FF]);
+	fake.trigger(0x27182818);
+	require!(fake.is_programming() == true);
+	fake.finish_operation();
+	require!(fake.read_error() == 0);
+	require!(fake.is_programming() == false);
+	require!(fake.read(512) == 0xFFFFFFFF);
+	require!(fake.read(1023) == 0xFFFFFFFF);
+	require!(fake.read(1300) == 0xFFFF00FF);
+	require!(fake.read(1301) == 0xFFFAFFFF);
+
+	// Operation 4: successful erase of the second page. Confirms the erase
+	// does not affect the third page.
+	fake.set_transaction(512, 0);
+	require!(fake.is_programming() == false);
+	fake.trigger(0x31415927);
+	require!(fake.is_programming() == true);
+	fake.finish_operation();
+	require!(fake.read_error() == 0);
+	require!(fake.is_programming() == false);
+	require!(fake.read(512) == 0xFFFFFFFF);
+	require!(fake.read(1023) == 0xFFFFFFFF);
+	require!(fake.read(1300) == 0xFFFF00FF);
+	require!(fake.read(1301) == 0xFFFAFFFF);
+
+	// Operation 5: successful erase of the third page. Verifies the erase
+	// affects the values in the third page.
+	fake.set_transaction(1024, 0);
+	require!(fake.is_programming() == false);
+	fake.trigger(0x31415927);
+	require!(fake.is_programming() == true);
+	fake.finish_operation();
+	require!(fake.read_error() == 0);
+	require!(fake.is_programming() == false);
+	require!(fake.read(512) == 0xFFFFFFFF);
+	require!(fake.read(1023) == 0xFFFFFFFF);
+	require!(fake.read(1300) == 0xFFFFFFFF);
+	require!(fake.read(1301) == 0xFFFFFFFF);
+
+	true
+}

--- a/userspace/h1b_tests/src/hil/flash/h1b_hw.rs
+++ b/userspace/h1b_tests/src/hil/flash/h1b_hw.rs
@@ -12,5 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod fake;
-mod h1b_hw;
+#[test]
+fn flash_size() -> bool {
+    core::mem::size_of::<h1b::hil::flash::h1b_hw::H1bHw>() == 384
+}

--- a/userspace/h1b_tests/src/hil/flash/mock_alarm.rs
+++ b/userspace/h1b_tests/src/hil/flash/mock_alarm.rs
@@ -1,0 +1,42 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[cfg(test)]
+pub struct MockAlarm {
+	now: core::cell::Cell<u32>,
+	setpoint: core::cell::Cell<Option<u32>>,
+}
+
+#[cfg(test)]
+impl MockAlarm {
+	pub fn new() -> MockAlarm {
+		MockAlarm { now: Default::default(), setpoint: Default::default() }
+	}
+
+	pub fn set_time(&self, new_time: u32) { self.now.set(new_time); }
+}
+
+#[cfg(test)]
+impl kernel::hil::time::Time for MockAlarm {
+	type Frequency = kernel::hil::time::Freq1KHz;
+	fn disable(&self) { self.setpoint.set(None); }
+	fn is_armed(&self) -> bool { self.setpoint.get().is_some() }
+}
+
+#[cfg(test)]
+impl kernel::hil::time::Alarm for MockAlarm {
+	fn now(&self) -> u32 { self.now.get() }
+	fn set_alarm(&self, tics: u32) { self.setpoint.set(Some(tics)); }
+	fn get_alarm(&self) -> u32 { self.setpoint.get().unwrap_or(0) }
+}

--- a/userspace/h1b_tests/src/hil/flash/mod.rs
+++ b/userspace/h1b_tests/src/hil/flash/mod.rs
@@ -12,9 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/// A client of the Flash driver -- receives callbacks when flash operations
-/// complete.
-pub trait Client {
-    fn erase_done(&self, ::kernel::ReturnCode);
-    fn write_done(&self, ::kernel::ReturnCode);
-}
+mod fake;

--- a/userspace/h1b_tests/src/hil/flash/mod.rs
+++ b/userspace/h1b_tests/src/hil/flash/mod.rs
@@ -14,3 +14,5 @@
 
 mod fake;
 mod h1b_hw;
+mod mock_alarm;
+mod smart_program;

--- a/userspace/h1b_tests/src/hil/flash/smart_program.rs
+++ b/userspace/h1b_tests/src/hil/flash/smart_program.rs
@@ -1,0 +1,155 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[test]
+fn decode_error() -> bool {
+	use { h1b::hil::flash::smart_program, test::require };
+	require!(smart_program::decode_error(0b100000000101001) == kernel::ReturnCode::FAIL);
+	require!(smart_program::decode_error(0b100000000000010) == kernel::ReturnCode::ESIZE);
+	require!(smart_program::decode_error(0b000000000001000) == kernel::ReturnCode::FAIL);
+	true
+}
+
+#[test]
+fn div_round_up() -> bool {
+	use { h1b::hil::flash::smart_program, test::require };
+	require!(smart_program::div_round_up(0, 1) == 0);
+	require!(smart_program::div_round_up(1, 1) == 1);
+	require!(smart_program::div_round_up(3, 2) == 2);
+	require!(smart_program::div_round_up(4, 2) == 2);
+	require!(smart_program::div_round_up(0, core::u32::MAX) == 0);
+	require!(smart_program::div_round_up(core::u32::MAX, core::u32::MAX) == 1);
+	require!(smart_program::div_round_up(core::u32::MAX - 5, core::u32::MAX) == 1);
+	require!(smart_program::div_round_up(core::u32::MAX, core::u32::MAX) == 1);
+	true
+}
+
+#[test]
+fn successful_program() -> bool {
+	use { h1b::hil::flash::Hardware, kernel::hil::time::Alarm, test::require };
+	let alarm = crate::hil::flash::mock_alarm::MockAlarm::new();
+	let hw = h1b::hil::flash::fake::FakeHw::new();
+	hw.set_transaction(1300, 1);
+	hw.set_write_data(&[0xFFFF0FFF]);
+
+	// First attempt.
+	let mut state = h1b::hil::flash::smart_program::SmartProgramState::init(9);
+	state = state.step(&alarm, &hw, 0x27182818, /*is_timeout:*/ false);
+	require!(alarm.get_alarm() == alarm.now() + 150);
+	require!(hw.is_programming() == true);
+	require!(state.return_code() == None);
+	alarm.set_time(50);
+
+	// Inject a spurious interrupt.
+	state = state.step(&alarm, &hw, 0x27182818, /*is_timeout:*/ false);
+	require!(alarm.get_alarm() == 150);
+	require!(hw.is_programming() == true);
+	require!(state.return_code() == None);
+	alarm.set_time(100);
+	hw.finish_operation();
+
+	// Finish.
+	state = state.step(&alarm, &hw, 0x27182818, /*is_timeout:*/ false);
+	require!(alarm.get_alarm() == 0);
+	require!(hw.is_programming() == false);
+	require!(state.return_code() == Some(kernel::ReturnCode::SUCCESS));
+	true
+}
+
+#[test]
+fn retries() -> bool {
+	use { h1b::hil::flash::Hardware, kernel::hil::time::Alarm, test::require };
+	let alarm = crate::hil::flash::mock_alarm::MockAlarm::new();
+	let hw = h1b::hil::flash::fake::FakeHw::new();
+	hw.set_transaction(1300, 1);
+	hw.set_write_data(&[0xFFFF0FFF]);
+
+	// First programming attempt.
+	let mut state = h1b::hil::flash::smart_program::SmartProgramState::init(9);
+	state = state.step(&alarm, &hw, 0x27182818, /*is_timeout:*/ false);
+	require!(alarm.get_alarm() == alarm.now() + 150);
+	require!(hw.is_programming() == true);
+	require!(state.return_code() == None);
+	alarm.set_time(100);
+	hw.inject_error(0b100);
+
+	// Second attempt.
+	state = state.step(&alarm, &hw, 0x27182818, /*is_timeout:*/ false);
+	require!(alarm.get_alarm() == alarm.now() + 150);
+	require!(hw.is_programming() == true);
+	require!(state.return_code() == None);
+	alarm.set_time(200);
+	hw.finish_operation();
+
+	// Finish.
+	state = state.step(&alarm, &hw, 0x27182818, /*is_timeout:*/ false);
+	require!(alarm.get_alarm() == 0);
+	require!(hw.is_programming() == false);
+	require!(state.return_code() == Some(kernel::ReturnCode::SUCCESS));
+	true
+}
+
+/// Keep throwing errors until the max retry count.
+#[test]
+fn failed() -> bool {
+	use { h1b::hil::flash::Hardware, kernel::hil::time::Alarm, test::require };
+	let alarm = crate::hil::flash::mock_alarm::MockAlarm::new();
+	let hw = h1b::hil::flash::fake::FakeHw::new();
+	hw.set_transaction(1300, 1);
+	hw.set_write_data(&[0xFFFF0FFF]);
+	let mut state = h1b::hil::flash::smart_program::SmartProgramState::init(9);
+
+	for i in 0..9 {
+		alarm.set_time(100 * i);
+		state = state.step(&alarm, &hw, 0x27182818, /*is_timeout:*/ false);
+		require!(alarm.get_alarm() == alarm.now() + 150);
+		require!(hw.is_programming() == true);
+		require!(state.return_code() == None);
+		hw.inject_error(0b100);
+	}
+
+	// Finish.
+	state = state.step(&alarm, &hw, 0x27182818, /*is_timeout:*/ false);
+	require!(alarm.get_alarm() == 0);
+	require!(hw.is_programming() == false);
+	require!(state.return_code() == Some(kernel::ReturnCode::FAIL));
+	true
+}
+
+#[test]
+fn timeout() -> bool {
+	use { h1b::hil::flash::Hardware, kernel::hil::time::Alarm, test::require };
+	let alarm = crate::hil::flash::mock_alarm::MockAlarm::new();
+	let hw = h1b::hil::flash::fake::FakeHw::new();
+	hw.set_transaction(1300, 1);
+	hw.set_write_data(&[0xFFFF0FFF]);
+
+	// First programming attempt.
+	let mut state = h1b::hil::flash::smart_program::SmartProgramState::init(9);
+	state = state.step(&alarm, &hw, 0x27182818, /*is_timeout:*/ false);
+	require!(alarm.get_alarm() == alarm.now() + 150);
+	require!(hw.is_programming() == true);
+	require!(state.return_code() == None);
+
+	// Timeout: reset hardware and advance the time.
+	hw.inject_error(0);
+	alarm.set_time(200);
+
+	// Alarm trigger.
+	state = state.step(&alarm, &hw, 0x27182818, /*is_timeout:*/ true);
+	require!(alarm.get_alarm() == 0);
+	require!(hw.is_programming() == false);
+	require!(state.return_code() == Some(kernel::ReturnCode::FAIL));
+	true
+}

--- a/userspace/h1b_tests/src/hil/mod.rs
+++ b/userspace/h1b_tests/src/hil/mod.rs
@@ -12,9 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/// A client of the Flash driver -- receives callbacks when flash operations
-/// complete.
-pub trait Client {
-    fn erase_done(&self, ::kernel::ReturnCode);
-    fn write_done(&self, ::kernel::ReturnCode);
-}
+mod flash;

--- a/userspace/h1b_tests/src/lib.rs
+++ b/userspace/h1b_tests/src/lib.rs
@@ -14,6 +14,8 @@
 
 #![no_std]
 
+mod hil;
+
 #[test]
 fn basic_test() -> bool {
     use core::fmt::Write;


### PR DESCRIPTION
This is an implementation detail of the full flash driver, and contains most of the async-related complexity.

Commits new in this PR:

1. Add a state machine for asynchronously driving the flash controller's...

```
----------------------
`make prtest` summary:
----------------------
git rev-parse HEAD
eaaa96eb6b4a9b9eea2544c2ee45010c733a09d2
git status
On branch smart-program
Your branch is up to date with 'origin/smart-program'.

nothing to commit, working tree clean
```