### PR TITLE
Correctly handle unexpected and bad packets by stalling FIFOs.

### DIFF
--- a/h1b/src/usb/mod.rs
+++ b/h1b/src/usb/mod.rs
@@ -126,7 +126,6 @@ const EP0_OUT_BUFFER_COUNT: usize = 2;
 /// StringDescriptors, which are provided by the boot sequence. The
 /// meaning of each StringDescriptor is defined by its index, in
 /// usb::constants.
-///
 
 pub struct USB<'a> {
     registers: StaticRef<Registers>,


### PR DESCRIPTION
This removes all panic! calls in the USB driver in response to packets; it changes the behavior to the correct specified behavior, stalling the FIFOs.

```
----------------------
`make prtest` summary:
----------------------
git rev-parse HEAD
54d885635573b329b8a94003bd62e43ccc5deae1
git status
On branch remove_usb_panic_calls
Your branch is up to date with 'origin/remove_usb_panic_calls'.

nothing to commit, working tree clean
```
