### PR TITLE
Add Google Cloud Build configs for a Rust toolchain image.

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -15,7 +15,7 @@
 # Prevent cargo from downloading the crates index or crates: all source should
 # be vendored in third_party/
 [http]
-proxy = "socks://proxy.invalid/"
+proxy = "socks://cargo.invalid/"
 
 # Point cargo to our vendored dependencies.
 [source.crates-io]

--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,0 +1,19 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+.gcloudignore
+.git
+.gitignore
+#!include:.gitignore
+!third_party/elf2tab/Cargo.lock

--- a/doc/gcb.md
+++ b/doc/gcb.md
@@ -1,0 +1,20 @@
+Google Cloud Build
+==================
+
+### Overview
+
+Tock-on-Titan uses [Cloud Build](https://cloud.google.com/cloud-build) for test
+infrastructure.
+
+Tock-on-Titan uses a "toolchain container" uploaded into [Container
+Registry](https://cloud.google.com/container-registry) as its build toolchain.
+This image should be rebuilt manually whenever the Rust toolchains used by
+Tock-on-Titan change (e.g. after a major `tock` or `libtock-rs` update).
+
+### Rebuilding the Toolchain Image
+
+To rebuild the toolchain image, run (in `tock-on-titan/`):
+
+```
+gcloud builds submit --config gcb/tock-toolchain.yaml gcb
+```

--- a/gcb/Dockerfile.tock-toolchain
+++ b/gcb/Dockerfile.tock-toolchain
@@ -1,0 +1,39 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM launcher.gcr.io/google/debian9
+
+ENV CARGO_HOME=/root/cargo \
+    PATH=$PATH:/root/cargo/bin \
+    RUSTUP_HOME=/root/rustup
+
+RUN apt-get update && apt-get install --no-install-recommends -y curl make && \
+    curl -sSf 'https://sh.rustup.rs/' | sh -s -- --default-toolchain none -y \
+    && apt-get purge -y curl && apt-get -y autoremove
+
+# ------------------------------------------------------------------------------
+# Configure additional toolchains here in the next two commands. Note that we
+# only need to add the thumbv7m target for toolchains used by embedded code --
+# elf2tab only needs the host toolchain.
+# ------------------------------------------------------------------------------
+RUN rustup toolchain add nightly-2018-08-16 \
+                         nightly-2018-11-30 \
+                         stable
+
+RUN rustup target add --toolchain nightly-2018-08-16 thumbv7m-none-eabi
+RUN rustup target add --toolchain nightly-2018-11-30 thumbv7m-none-eabi
+
+# Prevent rustup from trying to download new toolchains if the toolchains in
+# rust-toolchain are updated and this image is not updated.
+ENV RUSTUP_DIST_SERVER="https://rustup.invalid/"

--- a/gcb/tock-toolchain.yaml
+++ b/gcb/tock-toolchain.yaml
@@ -1,0 +1,23 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Google Cloud Build configuration for building a Docker image with the
+# toolchains necessary to build and run the tock-on-titan binaries and tests.
+
+steps:
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '-f', 'Dockerfile.tock-toolchain', '-t',
+         'gcr.io/opentitan/tock-toolchain', '.']
+
+images: ['gcr.io/opentitan/tock-toolchain']


### PR DESCRIPTION
This is the first step in developing a CI system for tock-on-titan. This toolchain image will (in a future PR) be used to build the firmware and launch tests.


```
----------------------
`make prtest` summary:
----------------------
git rev-parse HEAD
8cb75a3cf4459581308247db110405aa2a8af670
git status
On branch gcb-toolchain
Your branch is up to date with 'origin/gcb-toolchain'.

nothing to commit, working tree clean
```