### PR TITLE
Make the fake flash module indicate a programming error if its log fills rather than panicking.

### DIFF
--- a/h1b/src/hil/flash/fake.rs
+++ b/h1b/src/hil/flash/fake.rs
@@ -63,6 +63,13 @@ impl<'a> FakeHw<'a> {
             self.transaction_size.set(1);
         }
 
+        // Check if we will overflow the log. If this will overfill the log then
+        // indicate an error.
+        if self.log_len.get() + self.transaction_size.get() > self.log.len() {
+            // "Program failed" error.
+            return self.inject_error(0x8);
+        }
+
         for i in 0..self.transaction_size.get() {
             self.log[self.log_len.get()].set(LogEntry {
                 value:

--- a/userspace/h1b_tests/src/hil/flash/fake.rs
+++ b/userspace/h1b_tests/src/hil/flash/fake.rs
@@ -94,5 +94,20 @@ fn fake_hw() -> bool {
 	require!(fake.read(1300) == 0xFFFFFFFF);
 	require!(fake.read(1301) == 0xFFFFFFFF);
 
+	// At this point, the fake flash module's log is full. Attempting another
+	// operation should result in a flash error even if the operation is
+	// otherwise valid.
+	fake.set_transaction(1300, 1 - 1);
+	fake.set_write_data(&[0xABCDC0FF]);
+	fake.trigger(h1b::hil::flash::driver::WRITE_OPCODE);
+	require!(fake.is_programming() == true);
+	fake.finish_operation();
+	require!(fake.read_error() == 0x8);
+	require!(fake.is_programming() == false);
+	require!(fake.read(512) == 0xFFFFFFFF);
+	require!(fake.read(1023) == 0xFFFFFFFF);
+	require!(fake.read(1300) == 0xFFFFFFFF);
+	require!(fake.read(1301) == 0xFFFFFFFF);
+
 	true
 }


### PR DESCRIPTION
This will allow us to add the nonvolatile storage capsule to the kernel before the flash driver is finished. Once the operation count limit is reached, further flash writes will fail.

```
----------------------
`make prtest` summary:
----------------------
git rev-parse HEAD
c13924a8725caca2276af1d655a60ec2f8cf7592
git status
On branch fake-flash-overflow-error
Your branch is up to date with 'origin/fake-flash-overflow-error'.

nothing to commit, working tree clean
```