### PR TITLE
Add erase functionality to the flash driver.

### DIFF
--- a/h1b/src/hil/flash/driver.rs
+++ b/h1b/src/hil/flash/driver.rs
@@ -61,6 +61,13 @@ impl<'d, A: Alarm, H: Hardware<'d>> Flash<'d, A, H> {
         }
     }
 
+    /// Erases the specified flash page, setting it to all ones.
+    pub fn erase(&self, page: usize) -> ReturnCode {
+        if self.program_in_progress() { return ReturnCode::EBUSY; }
+        self.smart_program(ERASE_OPCODE, 45, 512 * page, 1);
+        ReturnCode::SUCCESS
+    }
+
     /// Writes a buffer (of up to 32 words) into the given location in flash.
     /// The target location is specific as an offset from the beginning of flash
     /// in units of words.

--- a/userspace/h1b_tests/src/hil/flash/driver.rs
+++ b/userspace/h1b_tests/src/hil/flash/driver.rs
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 #[cfg(test)]
+use { h1b::hil::flash::Hardware, kernel::hil::time::Alarm, test::require };
+
+#[cfg(test)]
 #[derive(Clone,Copy,PartialEq)]
 enum MockClientState {
 	EraseDone(kernel::ReturnCode),
@@ -45,13 +48,119 @@ impl h1b::hil::flash::Client for MockClient {
 }
 
 #[test]
-fn successful_program() -> bool {
-	use { h1b::hil::flash::Hardware, kernel::hil::time::Alarm, test::require };
+fn erase() -> bool {
 	let alarm = crate::hil::flash::mock_alarm::MockAlarm::new();
 	let client = MockClient::new();
 	let hw = h1b::hil::flash::fake::FakeHw::new();
-	hw.set_transaction(1300, 1);
-	hw.set_write_data(&[0xFFFF0FFF]);
+
+	// First attempt.
+	let driver = unsafe { h1b::hil::flash::Flash::new(&alarm, &hw) };
+	hw.set_client(&driver);
+	driver.set_client(&client);
+	require!(driver.erase(2) == kernel::ReturnCode::SUCCESS);
+	require!(alarm.get_alarm() == alarm.now() + 150);
+	require!(client.state() == None);
+	require!(hw.is_programming() == true);
+
+	// Inject a spurious interrupt.
+	alarm.set_time(50);
+	require!(alarm.get_alarm() == 150);
+	require!(hw.is_programming() == true);
+	require!(client.state() == None);
+
+	// Indicate an error, let the driver retry.
+	alarm.set_time(100);
+	hw.inject_error(0b100);
+	require!(alarm.get_alarm() == 250);
+	require!(hw.is_programming() == true);
+	require!(client.state() == None);
+
+	// Let the operation finish successfully.
+	alarm.set_time(200);
+	hw.finish_operation();
+	require!(alarm.get_alarm() == 0);
+	require!(hw.is_programming() == false);
+	require!(hw.read(1300) == 0xFFFFFFFF);
+	require!(client.state() == Some(MockClientState::EraseDone(kernel::ReturnCode::SUCCESS)));
+
+	true
+}
+
+#[test]
+fn erase_max_retries() -> bool {
+	let alarm = crate::hil::flash::mock_alarm::MockAlarm::new();
+	let client = MockClient::new();
+	let hw = h1b::hil::flash::fake::FakeHw::new();
+	let driver = unsafe { h1b::hil::flash::Flash::new(&alarm, &hw) };
+	hw.set_client(&driver);
+	driver.set_client(&client);
+	require!(driver.erase(2) == kernel::ReturnCode::SUCCESS);
+	require!(alarm.get_alarm() == alarm.now() + 150);
+	require!(client.state() == None);
+	require!(hw.is_programming() == true);
+
+	for i in 1..45 {
+		// Indicate an error, let the driver retry.
+		alarm.set_time(100 * i);
+		hw.inject_error(0b100);
+		require!(alarm.get_alarm() == alarm.now() + 150);
+		require!(hw.is_programming() == true);
+		require!(client.state() == None);
+	}
+
+	// Last try.
+	hw.inject_error(0b100);
+	require!(alarm.get_alarm() == 0);
+	require!(hw.is_programming() == false);
+	require!(client.state() == Some(MockClientState::EraseDone(kernel::ReturnCode::FAIL)));
+	require!(hw.read(1300) == 0xFFFFFFFF);
+
+	true
+}
+
+#[test]
+fn write_then_erase() -> bool {
+	let alarm = crate::hil::flash::mock_alarm::MockAlarm::new();
+	let client = MockClient::new();
+	let hw = h1b::hil::flash::fake::FakeHw::new();
+
+	// Write
+	let driver = unsafe { h1b::hil::flash::Flash::new(&alarm, &hw) };
+	hw.set_client(&driver);
+	driver.set_client(&client);
+	require!(driver.write(1300, &[0xFFFFABCD]) == kernel::ReturnCode::SUCCESS);
+	require!(alarm.get_alarm() == alarm.now() + 150);
+	require!(client.state() == None);
+	require!(hw.is_programming() == true);
+	alarm.set_time(100);
+	hw.finish_operation();
+	require!(alarm.get_alarm() == 0);
+	require!(hw.is_programming() == false);
+	require!(hw.read(1300) == 0xFFFFABCD);
+	require!(client.state() == Some(MockClientState::WriteDone(kernel::ReturnCode::SUCCESS)));
+
+	// Erase
+	let driver = unsafe { h1b::hil::flash::Flash::new(&alarm, &hw) };
+	hw.set_client(&driver);
+	driver.set_client(&client);
+	require!(driver.erase(2) == kernel::ReturnCode::SUCCESS);
+	require!(alarm.get_alarm() == alarm.now() + 150);
+	require!(hw.is_programming() == true);
+	alarm.set_time(200);
+	hw.finish_operation();
+	require!(alarm.get_alarm() == 0);
+	require!(hw.is_programming() == false);
+	require!(hw.read(1300) == 0xFFFFFFFF);
+	require!(client.state() == Some(MockClientState::EraseDone(kernel::ReturnCode::SUCCESS)));
+
+	true
+}
+
+#[test]
+fn successful_program() -> bool {
+	let alarm = crate::hil::flash::mock_alarm::MockAlarm::new();
+	let client = MockClient::new();
+	let hw = h1b::hil::flash::fake::FakeHw::new();
 
 	// First attempt.
 	let driver = unsafe { h1b::hil::flash::Flash::new(&alarm, &hw) };
@@ -87,7 +196,7 @@ fn successful_program() -> bool {
 
 #[test]
 fn timeout() -> bool {
-	use { h1b::hil::flash::Hardware, kernel::hil::time::{Alarm, Client}, test::require };
+	use kernel::hil::time::Client;
 	let alarm = crate::hil::flash::mock_alarm::MockAlarm::new();
 	let client = MockClient::new();
 	let hw = h1b::hil::flash::fake::FakeHw::new();
@@ -113,12 +222,9 @@ fn timeout() -> bool {
 
 #[test]
 fn write_max_retries() -> bool {
-	use { h1b::hil::flash::Hardware, kernel::hil::time::Alarm, test::require };
 	let alarm = crate::hil::flash::mock_alarm::MockAlarm::new();
 	let client = MockClient::new();
 	let hw = h1b::hil::flash::fake::FakeHw::new();
-	hw.set_transaction(1300, 1);
-	hw.set_write_data(&[0xFFFF0FFF]);
 	let driver = unsafe { h1b::hil::flash::Flash::new(&alarm, &hw) };
 	hw.set_client(&driver);
 	driver.set_client(&client);


### PR DESCRIPTION
Commits new in this PR:

1. Add erase functionality to the flash driver.

```
----------------------
`make prtest` summary:
----------------------
git rev-parse HEAD
ec0b2ecc6bea55de9d0e7d700ebd83eb2c6c3608
git status
On branch flash-erase
Your branch is up to date with 'origin/flash-erase'.

nothing to commit, working tree clean
```