### PR TITLE
USB suspend support

### DIFF
--- a/golf2/src/main.rs
+++ b/golf2/src/main.rs
@@ -126,8 +126,8 @@ pub unsafe fn reset_handler() {
     let timerhs = {
         use h1b::pmu::*;
         use h1b::timeus::Timeus;
-        Clock::new(PeripheralClock::Bank1(PeripheralClock1::TimeUs0Timer)).enable();
-        Clock::new(PeripheralClock::Bank1(PeripheralClock1::TimeLs0)).enable();
+        Clock::new(PeripheralClock::Bank1(Peripheral1::TimeUs0Timer)).enable();
+        Clock::new(PeripheralClock::Bank1(Peripheral1::TimeLs0)).enable();
         let timer = Timeus::new(0);
         timer
     };
@@ -137,7 +137,7 @@ pub unsafe fn reset_handler() {
 
     {
         use h1b::pmu::*;
-        Clock::new(PeripheralClock::Bank0(PeripheralClock0::Gpio0)).enable();
+        Clock::new(PeripheralClock::Bank0(Peripheral0::Gpio0)).enable();
         let pinmux = &mut *h1b::pinmux::PINMUX;
         // LED_0
         pinmux.dioa11.select.set(h1b::pinmux::Function::Gpio0Gpio0);

--- a/golf2/src/main.rs
+++ b/golf2/src/main.rs
@@ -47,7 +47,6 @@ use kernel::hil::entropy::Entropy32;
 use kernel::hil::rng::Rng;
 
 use h1b::crypto::dcrypto::Dcrypto;
-use h1b::usb::{Descriptor, StringDescriptor};
 
 // State for loading apps
 const NUM_PROCS: usize = 1;
@@ -77,47 +76,6 @@ pub struct Golf {
     u2f_usb: &'static h1b::usb::driver::U2fSyscallDriver<'static>,
     uint_printer: debug_syscall::UintPrinter,
 }
-
-static mut STRINGS: [StringDescriptor; 7] = [
-    StringDescriptor {
-        b_length: 4,
-        b_descriptor_type: Descriptor::String as u8,
-        b_string: &[0x0409], // English
-    },
-    StringDescriptor {
-        b_length: 24,
-        b_descriptor_type: Descriptor::String as u8,
-        b_string: &[0x0047, 0x006f, 0x006f, 0x0067, 0x006c, 0x0065, 0x0020, 0x0049, 0x006e, 0x0063, 0x002e], // Google Inc.
-    },
-    StringDescriptor {
-        b_length: 14,
-        b_descriptor_type: Descriptor::String as u8,
-        b_string: &[0x0070, 0x0072, 0x006f, 0x0074, 0x006f, 0x0032], // proto2
-    },
-    StringDescriptor {
-        b_length: 54,
-        b_descriptor_type: Descriptor::String as u8,
-        b_string: &[0x0070, 0x0072, 0x006F, 0x0074, 0x006F, 0x0032, 0x005F, 0x0076, 0x0031, 0x002E, 0x0031, 0x002E, 0x0038, 0x0037, 0x0031, 0x0033, 0x002D, 0x0030, 0x0031, 0x0033, 0x0032, 0x0031, 0x0037, 0x0064, 0x0039, 0x0031], // proto2-...
-    },
-    // Why does this need 3 l (0x6C)? Linux seems to be truncating last one.
-    // Verified GetDescriptor for the String is returning complete information.
-    // -pal
-    StringDescriptor {
-        b_length: 12,
-        b_descriptor_type: Descriptor::String as u8,
-        b_string: &[0x0053, 0x0068, 0x0065, 0x006C, 0x006C, 0x006C], // Shell
-    },
-    StringDescriptor {
-        b_length: 8,
-        b_descriptor_type: Descriptor::String as u8,
-        b_string: &[0x0042, 0x004C, 0x0041, 0x0048],  // BLAH
-    },
-    StringDescriptor {
-        b_length: 20,
-        b_descriptor_type: Descriptor::String as u8,
-        b_string: &[0x0048, 0x006F, 0x0074, 0x0065, 0x006C, 0x0020, 0x0055, 0x0032, 0x0046], // Hotel U2F
-    },
-];
 
 #[no_mangle]
 pub unsafe fn reset_handler() {
@@ -309,7 +267,8 @@ pub unsafe fn reset_handler() {
                         None,
                         Some(0x18d1),  // Google vendor ID
                         Some(0x5026),  // proto2
-                        &mut STRINGS);
+                        &mut h1b::usb::u2f::STRINGS);
+
     let golf2 = Golf {
         console: console,
         gpio: gpio,

--- a/h1b/src/chip.rs
+++ b/h1b/src/chip.rs
@@ -16,6 +16,7 @@ use cortexm3;
 use crypto;
 use gpio;
 use kernel::Chip;
+use pmu;
 use timels;
 use trng;
 use uart;
@@ -110,9 +111,7 @@ impl Chip for Hotel {
     }
 
     fn sleep(&self) {
-        unsafe {
-                cortexm3::scb::unset_sleepdeep();
-        }
+        pmu::prepare_for_sleep();
 
         unsafe {
             cortexm3::support::wfi();

--- a/h1b/src/chip.rs
+++ b/h1b/src/chip.rs
@@ -116,6 +116,8 @@ impl Chip for Hotel {
         unsafe {
             cortexm3::support::wfi();
         }
+
+        pmu::resume_from_sleep();
     }
 
     unsafe fn atomic<F, R>(&self, f: F) -> R

--- a/h1b/src/crypto/dcrypto.rs
+++ b/h1b/src/crypto/dcrypto.rs
@@ -56,7 +56,7 @@ use kernel::common::cells::TakeCell;
 use kernel::common::cells::VolatileCell;
 use kernel::ReturnCode;
 
-use pmu::{Clock, PeripheralClock, PeripheralClock0, reset_dcrypto};
+use pmu::{Clock, PeripheralClock, Peripheral0, reset_dcrypto};
 
 
 
@@ -288,7 +288,7 @@ impl<'a> DcryptoEngine<'a> {
             ReturnCode::EALREADY
         } else {
             // Enable PMU and reset it
-            unsafe {Clock::new(PeripheralClock::Bank0(PeripheralClock0::Crypto0)).enable();}
+            unsafe {Clock::new(PeripheralClock::Bank0(Peripheral0::Crypto0)).enable();}
             reset_dcrypto();
 
             // Turn off random no-ops

--- a/h1b/src/pinmux.rs
+++ b/h1b/src/pinmux.rs
@@ -160,6 +160,10 @@ pub struct Registers {
     pub xo0_testbus5: Peripheral,
     pub xo0_testbus6: Peripheral,
     pub xo0_testbus7: Peripheral,
+    pub exit_en0: VolatileCell<u32>,
+    pub exit_edge0: VolatileCell<u32>,
+    pub exit_inv0: VolatileCell<u32>,
+    pub hold: VolatileCell<u32>
 }
 
 pub const PINMUX: *mut Registers = 0x40060000 as *mut Registers;

--- a/h1b/src/pmu.rs
+++ b/h1b/src/pmu.rs
@@ -44,67 +44,147 @@
 use cortexm3;
 use core::mem::transmute;
 use kernel::common::cells::VolatileCell;
+use kernel::common::registers::{ReadOnly, ReadWrite};
+
+register_bitfields![u32,
+    Reset [
+        Value           OFFSET(0) NUMBITS(32) []
+    ],
+    ClearReset [
+        Value           OFFSET(0) NUMBITS(32) []
+    ],
+    ResetSource [
+        PowerOnReset              0,
+        LowPowerExit              1,
+        Watchdog                  2,
+        Lockup                    3,
+        SysReset                  4,
+        Software                  5,
+        Brownout                  6,
+        Security                  7
+    ],
+    GlobalReset [
+        Value           OFFSET(0) NUMBITS(32) []
+    ],
+    LowPowerDisable [
+        Start                     0,
+        VddlOff                   1,
+        FlashOff                  2,
+        OscillatorOff             3,
+        JitterRCOff               4
+    ],
+    LowPowerBypass [
+        Vddl                      0,
+        Flash                     1,
+        Oscillator                2,
+        OscillatorComparator      3,
+        JitterRC                  4,
+        TimerRC                   5,
+        FlashPowerDown            6,
+        VddlVddaonIsolation       7,
+        VddxoVddaonIsolation      8
+    ],
+    WakeupInterruptController [
+        Processor0                0
+    ],
+    SystemVtor [
+        Value           OFFSET(0) NUMBITS(32) []
+    ],
+    NapEnable [
+        Value           OFFSET(0) NUMBITS(32) []
+    ],
+    BatteryLevelOk [
+        OK                        0
+    ],
+    MemoryClock [
+        BankClock0                0,
+        BankClock1                1,
+        BankClock2                2,
+        BankClock3                3,
+        BankClock4                4,
+        BankClock5                5,
+        BankClock6                6
+    ],
+    PeripheralClock0 [
+        Camo                      0,
+        Dcrypto                   1,
+        Dma                       2,
+        Flash                     3,
+        Fuse                      4,
+        GlobalSec                 5,
+        GlobalSecTimer            6,
+        GlobalSecHs               7,
+        Gpio0                     8,
+        Gpio1                     9,
+        I2C0                     10,
+        I2C1                     11,
+        I2CS0                    12,
+        KeyManager               13,
+        PeripheralApb0           14,
+        PeripheralApb1           15,
+        PeripheralApb2           16,
+        PeripheralApb2Timer      17,
+        PeripheralApb3           18,
+        PeripheralApb3Hs         19,
+        PinMux                   20,
+        Pmu                      21,
+        RBox                     22,
+        Rdd                      23,
+        Rtc                      24,
+        RtcTimer                 25,
+        Spi0Hs                   26,
+        Spi1Hs                   27,
+        Sps                      28,
+        SpsTimerHs               29,
+        Swdp                     30,
+        Temp                     31
+    ],
+    PeripheralClock1 [
+        TimeHs0Timer              0,
+        TimeHs1Timer              1,
+        TimeLs                    2,
+        Timerus                   3,
+        Trng                      4,
+        Uart0                     5,
+        Uart1                     6,
+        Uart2                     7,
+        Usb                       8,
+        UsbTimerHs                9,
+        VoltRO                   10,
+        WatchdogRO               11,
+        XO                       12,
+        XOTimer                  13,
+        PeripheralMasterMatrix   14,
+        PeripheralMaster         15
+    ]
+];
 
 /// Registers for the Power Management Unit (PMU)
 // Non-public fields prefixed with "_" mark unused registers
 #[repr(C, packed)]
 pub struct PMURegisters {
-    reset: VolatileCell<u32>,
+    reset:                                 ReadWrite<u32, Reset::Register>,
     _set_reset: VolatileCell<u32>,
+    pub clear_reset:                       ReadWrite<u32, ClearReset::Register>,
+    pub reset_source:                      ReadOnly<u32, ResetSource::Register>,
 
-    /// Clear register for the reset source
-    pub clear_reset: VolatileCell<u32>,
-
-    /// Status for source of last reset event
-    ///
-    /// Bits 0-7 correspond to:
-    ///
-    /// | bit | Description                                       |
-    /// | --- | :------------------------------------------------ |
-    /// | 0   | Power on reset                                    |
-    /// | 1   | Low power exit                                    |
-    /// | 2   | Watchdog reset                                    |
-    /// | 3   | Lockup reset                                      |
-    /// | 4   | SYSRESET                                          |
-    /// | 5   | Software initiated reset through PMU_GLOBAL_RESET |
-    /// | 6   | Fast burnout circuit                              |
-    /// | 7   | Security breach reset                             |
-    ///
-    pub reset_source: VolatileCell<u32>,
-
-    /// Global chip reset
-    ///
-    /// Initiates a reset of the system similar to toggling the external reset
-    /// pin. To initiate a reset, write the key 0x7041776 to this register.
-    pub global_reset: VolatileCell<u32>,
-
-    pub low_power_disable: VolatileCell<u32>,
-
-    pub low_power_bypass: VolatileCell<u32>,
-
-    pub low_power_bypass_value: VolatileCell<u32>,
-
-    pub set_wakeup_interrupt_controller: VolatileCell<u32>,
-
-    pub clear_wakeup_interrupt_controller: VolatileCell<u32>,
-
+    /// To initiate a reset, write the key 0x7041776 to global_reset.
+    pub global_reset:                      ReadWrite<u32, GlobalReset::Register>,
+    pub low_power_disable:                 ReadWrite<u32, LowPowerDisable::Register>,
+    pub low_power_bypass:                  ReadWrite<u32, LowPowerBypass::Register>,
+    pub low_power_bypass_value:            ReadWrite<u32, LowPowerBypass::Register>,
+    pub set_wakeup_interrupt_controller:   ReadWrite<u32, WakeupInterruptController::Register>,
+    pub clear_wakeup_interrupt_controller: ReadWrite<u32, WakeupInterruptController::Register>,
     /// Value of the system vector table offset
-    pub sysvtor: VolatileCell<u32>,
-
-    /// Enable PMU to gate some clocks when processor is sleeping
-    pub nap_enable: VolatileCell<u32>,
+    pub sysvtor:                           ReadWrite<u32, SystemVtor::Register>,
+    pub nap_enable:                        ReadWrite<u32, NapEnable::Register>,
 
     _pmu_sw_pdb: VolatileCell<u32>,
     _pmu_sw_pdb_secure: VolatileCell<u32>,
     _pmu_vref: VolatileCell<u32>,
     _xtl_osc_bypass: VolatileCell<u32>,
     _flash_tm0_test_en_bypass: VolatileCell<u32>,
-
-    /// Battery level indicator
-    ///
-    /// When non-zero, the voltage level is higher than specified in the vref
-    /// register's BATMON field.
-    pub battery_level_ok: VolatileCell<u32>,
+    pub battery_level_ok:                  ReadOnly<u32, BatteryLevelOk::Register>,
 
     _b_reg_dig_ctrl: VolatileCell<u32>,
     _exitpd_mask: VolatileCell<u32>,
@@ -112,35 +192,13 @@ pub struct PMURegisters {
     _exitpd_mon: VolatileCell<u32>,
     _osc_ctrl: VolatileCell<u32>,
 
-    /// Turn on clocks for memory
-    ///
-    /// Bits 0-6 correspond to memory banks 0-6, respectively.
-    pub memory_clk_set: VolatileCell<u32>,
+    pub memory_clock_set:                  ReadWrite<u32, MemoryClock::Register>,
+    pub memory_clock_clear:                ReadWrite<u32, MemoryClock::Register>,
 
-    /// Turn off clocks for memory
-    ///
-    /// Bits 0-6 correspond to memory banks 0-6, respectively.
-    pub memory_clk_clear: VolatileCell<u32>,
-
-    /// Enable peripheral clocks (bank 0).
-    ///
-    /// Each bit corresponds to a different peripheral clock.
-    pub peripheral_clocks0_enable: VolatileCell<u32>,
-
-    /// Disable peripheral clocks (bank 0).
-    ///
-    /// Each bit corresponds to a different peripheral clock.
-    pub peripheral_clocks0_disable: VolatileCell<u32>,
-
-    /// Enable peripheral clocks (bank 1).
-    ///
-    /// Each bit corresponds to a different peripheral clock.
-    pub peripheral_clocks1_enable: VolatileCell<u32>,
-
-    /// Disable peripheral clocks (bank 1).
-    ///
-    /// Each bit corresponds to a different peripheral clock.
-    pub peripheral_clocks1_disable: VolatileCell<u32>,
+    pub peripheral_clocks0_enable:         ReadWrite<u32, PeripheralClock0::Register>,
+    pub peripheral_clocks0_disable:        ReadWrite<u32, PeripheralClock0::Register>,
+    pub peripheral_clocks1_enable:         ReadWrite<u32, PeripheralClock1::Register>,
+    pub peripheral_clocks1_disable:        ReadWrite<u32, PeripheralClock1::Register>,
 
     pub _peripheral_clocks0_ro_mask: VolatileCell<u32>,
     pub _peripheral_clocks1_ro_mask: VolatileCell<u32>,
@@ -153,10 +211,10 @@ pub struct PMURegisters {
 
     pub _clock0: VolatileCell<u32>,
     pub _reset0_write_enable: VolatileCell<u32>,
-    pub reset0: VolatileCell<u32>,
+    pub reset0:                            ReadWrite<u32, PeripheralClock0::Register>,
 
     pub _reset1_write_enable: VolatileCell<u32>,
-    pub _reset1: VolatileCell<u32>
+    pub _reset1:                           ReadWrite<u32, PeripheralClock1::Register>
 
 }
 
@@ -165,7 +223,7 @@ const PMU_BASE: isize = 0x40000000;
 static mut PMU: *mut PMURegisters = PMU_BASE as *mut PMURegisters;
 
 #[derive(Clone,Copy)]
-pub enum PeripheralClock0 {
+pub enum Peripheral0 {
     Camo0,
     Crypto0,
     Dma0,
@@ -202,7 +260,7 @@ pub enum PeripheralClock0 {
 }
 
 #[derive(Clone,Copy)]
-pub enum PeripheralClock1 {
+pub enum Peripheral1 {
     TimeHs0Timer,
     TimeHs1Timer,
     TimeLs0,
@@ -223,8 +281,8 @@ pub enum PeripheralClock1 {
 
 #[derive(Clone,Copy)]
 pub enum PeripheralClock {
-    Bank0(PeripheralClock0),
-    Bank1(PeripheralClock1),
+    Bank0(Peripheral0),
+    Bank1(Peripheral1),
 }
 
 /// Wrapper struct around `PeripheralClock` that can only be created by.

--- a/h1b/src/pmu.rs
+++ b/h1b/src/pmu.rs
@@ -434,4 +434,5 @@ pub fn resume_from_sleep() {
     /* Prevent accidental reentry */
     /* Cr50 code does this, don't know why, but better safe than sorry. -pal */
     registers.low_power_disable.set(0);
+    disable_deep_sleep();
 }

--- a/h1b/src/uart.rs
+++ b/h1b/src/uart.rs
@@ -52,7 +52,7 @@ use kernel::common::cells::TakeCell;
 use kernel::common::cells::VolatileCell;
 use kernel::hil;
 use kernel::ReturnCode;
-use pmu::{Clock, PeripheralClock, PeripheralClock1};
+use pmu::{Clock, PeripheralClock, Peripheral1};
 
 /// Registers for the UART controller
 #[allow(dead_code)]
@@ -72,11 +72,11 @@ const UART0_BASE: *mut Registers = 0x40600000 as *mut Registers;
 const UART1_BASE: *mut Registers = 0x40610000 as *mut Registers;
 const UART2_BASE: *mut Registers = 0x40620000 as *mut Registers;
 
-pub static mut UART0: UART = unsafe { UART::new(UART0_BASE, PeripheralClock1::Uart0Timer) };
+pub static mut UART0: UART = unsafe { UART::new(UART0_BASE, Peripheral1::Uart0Timer) };
 
-pub static mut UART1: UART = unsafe { UART::new(UART1_BASE, PeripheralClock1::Uart1Timer) };
+pub static mut UART1: UART = unsafe { UART::new(UART1_BASE, Peripheral1::Uart1Timer) };
 
-pub static mut UART2: UART = unsafe { UART::new(UART2_BASE, PeripheralClock1::Uart2Timer) };
+pub static mut UART2: UART = unsafe { UART::new(UART2_BASE, Peripheral1::Uart2Timer) };
 
 // A resumable buffer that tracks the last written index
 //struct Buffer {
@@ -98,7 +98,7 @@ pub struct UART {
 }
 
 impl UART {
-    const unsafe fn new(uart: *mut Registers, clock: PeripheralClock1) -> UART {
+    const unsafe fn new(uart: *mut Registers, clock: Peripheral1) -> UART {
         UART {
             regs: uart,
             clock: Clock::new(PeripheralClock::Bank1(clock)),

--- a/h1b/src/usb/mod.rs
+++ b/h1b/src/usb/mod.rs
@@ -29,7 +29,7 @@ use cortexm3::support;
 use kernel::ReturnCode;
 use kernel::common::cells::{OptionalCell, TakeCell};
 use kernel::common::registers::LocalRegisterCopy;
-use pmu::{Clock, PeripheralClock, Peripheral1};
+use pmu::{self,Clock, PeripheralClock, Peripheral1};
 
 use self::constants::*;
 use self::registers::{AhbConfig, AllEndpointInterrupt, DescFlag,
@@ -349,7 +349,9 @@ impl<'a> USB<'a> {
 
         if status.is_set(Interrupt::EarlySuspend) ||
             status.is_set(Interrupt::Suspend) {
+                print!("USB: Suspending device, entering deep sleep!\n");
                 // Currently do not support suspend
+                pmu::enable_deep_sleep();
             }
 
         if mask.is_set(Interrupt::StartOfFrame) &&

--- a/h1b/src/usb/mod.rs
+++ b/h1b/src/usb/mod.rs
@@ -259,7 +259,7 @@ impl<'a> USB<'a> {
 
     /// Reset the device in response to a USB RESET.
     fn usb_reset(&self) {
-        control_debug!("USB: WaitingForSetupPacket in reset.\n");
+        control_debug!("USB: resetting device.\n");
         self.state.set(USBState::WaitingForSetupPacket);
         // Reset device address field (bits 10:4) of device config
         self.registers.device_config.modify(DeviceConfig::DeviceAddress.val(0));

--- a/h1b/src/usb/mod.rs
+++ b/h1b/src/usb/mod.rs
@@ -29,7 +29,7 @@ use cortexm3::support;
 use kernel::ReturnCode;
 use kernel::common::cells::{OptionalCell, TakeCell};
 use kernel::common::registers::LocalRegisterCopy;
-use pmu::{Clock, PeripheralClock, PeripheralClock1};
+use pmu::{Clock, PeripheralClock, Peripheral1};
 
 use self::constants::*;
 use self::registers::{AhbConfig, AllEndpointInterrupt, DescFlag,
@@ -206,8 +206,8 @@ impl<'a> USB<'a> {
     const unsafe fn new() -> USB<'a> {
         USB {
             registers: StaticRef::new(BASE_ADDR),
-            core_clock: Clock::new(PeripheralClock::Bank1(PeripheralClock1::Usb0)),
-            timer_clock: Clock::new(PeripheralClock::Bank1(PeripheralClock1::Usb0TimerHs)),
+            core_clock: Clock::new(PeripheralClock::Bank1(Peripheral1::Usb0)),
+            timer_clock: Clock::new(PeripheralClock::Bank1(Peripheral1::Usb0TimerHs)),
             state: Cell::new(USBState::WaitingForSetupPacket),
             ep0_out_descriptors: TakeCell::empty(),
             ep0_out_buffers: Cell::new(None),

--- a/h1b/src/usb/registers.rs
+++ b/h1b/src/usb/registers.rs
@@ -286,6 +286,27 @@ register_bitfields![u32,
         SetNak                             OFFSET(27) NUMBITS(1)  [],
         Disable                            OFFSET(30) NUMBITS(1)  [],
         Enable                             OFFSET(31) NUMBITS(1)  []
+    ],
+
+    PowerClockGatingControl [
+        StopPhyClock                       OFFSET(0)  NUMBITS(1)  [],
+        GateHClock                         OFFSET(1)  NUMBITS(1)  [],
+        PowerClamp                         OFFSET(2)  NUMBITS(1)  [],
+        ResetPowerDownModule               OFFSET(3)  NUMBITS(1)  [],
+        Reserved                           OFFSET(4)  NUMBITS(1)  [],
+        EnableSleepClockGating             OFFSET(5)  NUMBITS(1)  [],
+        PhySleep                           OFFSET(6)  NUMBITS(1)  [],
+        Suspended                          OFFSET(7)  NUMBITS(1)  [],
+        ResetAfterSuspend                  OFFSET(8)  NUMBITS(1)  [],
+        RestoreMode                        OFFSET(9)  NUMBITS(1)  [
+            DeviceInitiated = 0,
+            HostInitiated   = 1
+        ],
+        EnableExtendedHibernation          OFFSET(10) NUMBITS(1)  [],
+        EnableHibernationClamp             OFFSET(11) NUMBITS(1)  [],
+        ExtendedHiberationSwitch           OFFSET(12) NUMBITS(1)  [],
+        EssentialRegisterValuesRestored    OFFSET(13) NUMBITS(1)  [],
+        RestoreValue                       OFFSET(14) NUMBITS(16) []
     ]
 ];
 
@@ -359,7 +380,7 @@ pub struct Registers {
     // 0xd00
     _reserved6: [u32; 64],
     // 0xe00
-    pub _power_clock_gating_control: VolatileCell<u32>,
+    pub power_clock_gating_control: ReadWrite<u32, PowerClockGatingControl::Register>,
 }
 
 #[repr(C)]

--- a/h1b/src/usb/u2f.rs
+++ b/h1b/src/usb/u2f.rs
@@ -17,10 +17,56 @@
 use kernel::ReturnCode;
 
 use usb::constants::EP_BUFFER_SIZE_WORDS;
+use usb::{Descriptor, StringDescriptor};
+
+pub static mut STRINGS: [StringDescriptor; 7] = [
+    StringDescriptor {
+        b_length: 4,
+        b_descriptor_type: Descriptor::String as u8,
+        b_string: &[0x0409], // English
+    },
+    StringDescriptor {
+        b_length: 24,
+        b_descriptor_type: Descriptor::String as u8,
+        b_string: &[0x0047, 0x006f, 0x006f, 0x0067, 0x006c, 0x0065, 0x0020, 0x0049, 0x006e, 0x0063, 0x002e], // Google Inc.
+    },
+    StringDescriptor {
+        b_length: 14,
+        b_descriptor_type: Descriptor::String as u8,
+        b_string: &[0x0070, 0x0072, 0x006f, 0x0074, 0x006f, 0x0032], // proto2
+    },
+    StringDescriptor {
+        b_length: 54,
+        b_descriptor_type: Descriptor::String as u8,
+        b_string: &[0x0070, 0x0072, 0x006F, 0x0074, 0x006F, 0x0032, 0x005F, 0x0076, 0x0031, 0x002E, 0x0031, 0x002E, 0x0038, 0x0037, 0x0031, 0x0033, 0x002D, 0x0030, 0x0031, 0x0033, 0x0032, 0x0031, 0x0037, 0x0064, 0x0039, 0x0031], // proto2-...
+    },
+    // Why does this need 3 l (0x6C)? Linux seems to be truncating last one.
+    // Verified GetDescriptor for the String is returning complete information.
+    // -pal
+    StringDescriptor {
+        b_length: 12,
+        b_descriptor_type: Descriptor::String as u8,
+        b_string: &[0x0053, 0x0068, 0x0065, 0x006C, 0x006C, 0x006C], // Shell
+    },
+    StringDescriptor {
+        b_length: 8,
+        b_descriptor_type: Descriptor::String as u8,
+        b_string: &[0x0042, 0x004C, 0x0041, 0x0048],  // BLAH
+    },
+    StringDescriptor {
+        b_length: 20,
+        b_descriptor_type: Descriptor::String as u8,
+        b_string: &[0x0048, 0x006F, 0x0074, 0x0065, 0x006C, 0x0020, 0x0055, 0x0032, 0x0046], // Hotel U2F
+    },
+];
+
 
 /// Trait a USB peripheral stack must implement to support the U2F syscall
 /// capsule.
 pub trait UsbHidU2f<'a> {
+    fn power_down(&self) -> ReturnCode;
+    fn power_up(&self) -> ReturnCode;
+
     fn set_u2f_client(&self, client: &'a UsbHidU2fClient<'a>);
 
     /// Reset the device and endpoints

--- a/userspace/u2f_app/u2f_transport.c
+++ b/userspace/u2f_app/u2f_transport.c
@@ -156,7 +156,7 @@ static void cancel_lock_timeout(void) {
  */
 static int u2fhid_cmd_lock(const uint32_t cid, const uint8_t duration) {
   if (!duration) {
-    printf("Lock %04lx canceled\n", cid);
+    //printf("Lock %04lx canceled\n", cid);
     lock_CID = 0;
     //hook_call_deferred(&cancel_lock_timeout_data, -1);
   } else {
@@ -411,6 +411,7 @@ static void u2fhid_cmd_init(U2FHID_FRAME *f_p) {
   //        response.init.cmd);
   //printf("bcnth:%02x bcntl:%02x ", response.init.bcnth, response.init.bcntl);
   usbu2f_put_frame(&response);
+  //printf("put frame\n");
 }
 
 void u2fhid_process_frame(U2FHID_FRAME *f_p);


### PR DESCRIPTION
This PR adds USB suspend/resume support to H1B. Sending a suspend from Linux causes the device to suspend properly. Resume is not seamless, due to some interactions with the Linux drivers. It takes a few messages to the device (or a few seconds) for Linux to fully recognize the device.

Note that this suspend/resume only operates on the USB peripheral: it does not currently put the core into a low-power state.

```
----------------------
`make prtest` summary:
----------------------
git rev-parse HEAD
ff0afbdcaad7d2f1bcf16771bfe19a94818693d3
git status
On branch usb_suspend_support
Your branch is up to date with 'origin/usb_suspend_support'.

nothing to commit, working tree clean
```

