### PR TITLE
Correct the `offset` value in the flash transaction parameters.

### DIFF
--- a/h1b/src/hil/flash/driver.rs
+++ b/h1b/src/hil/flash/driver.rs
@@ -64,7 +64,7 @@ impl<'d, A: Alarm, H: Hardware<'d>> Flash<'d, A, H> {
     /// Erases the specified flash page, setting it to all ones.
     pub fn erase(&self, page: usize) -> ReturnCode {
         if self.program_in_progress() { return ReturnCode::EBUSY; }
-        self.smart_program(ERASE_OPCODE, 45, 512 * page, 1);
+        self.smart_program(ERASE_OPCODE, 45, page * super::WORDS_PER_PAGE, 1);
         ReturnCode::SUCCESS
     }
 

--- a/h1b/src/hil/flash/h1b_hw.rs
+++ b/h1b/src/hil/flash/h1b_hw.rs
@@ -261,6 +261,10 @@ impl super::hardware::Hardware<'static> for H1bHw {
 
 	fn set_transaction(&self, offset: usize, size: usize) {
 		use self::TransactionParameters::{Offset,Size};
+		// The offset is relative to the beginning of the flash module. There
+		// are 128 pages per flash module.
+		// TODO(jrvanwhy): Assumes the read is from the second flash bank.
+		let offset = offset - 128 * super::WORDS_PER_PAGE;
 		self.transaction_parameters.write(Offset.val(offset as u32) + Size.val(size as u32));
 	}
 

--- a/h1b/src/hil/flash/mod.rs
+++ b/h1b/src/hil/flash/mod.rs
@@ -31,3 +31,6 @@ pub type Flash<'h, A> = self::driver::Flash<'static, A, self::h1b_hw::H1bHw>;
 
 pub use self::driver::Client;
 pub use self::hardware::Hardware;
+
+// Constants used by multiple submodules.
+const WORDS_PER_PAGE: usize = 512;


### PR DESCRIPTION
The offsets are specified relative to the start of each flash module, whereas the `h1b::hil::flash::Hardware` interface uses offsets that cross over the two modules. H1bHw needs to do the mapping between them. Because only the second module is in use, we can simply hardcode the transformation.

```
----------------------
`make prtest` summary:
----------------------
git rev-parse HEAD
3ab4628b2ed60a01e391a60f9017608b901c443c
git status
On branch page-offset
Your branch is up to date with 'origin/page-offset'.

nothing to commit, working tree clean
```