### PR TITLE
Flash fixes

### DIFF
--- a/h1b/src/chip.rs
+++ b/h1b/src/chip.rs
@@ -15,7 +15,6 @@
 use cortexm3;
 use crypto;
 use gpio;
-use hil;
 use kernel::Chip;
 use timels;
 use trng;
@@ -55,7 +54,6 @@ impl Chip for Hotel {
                     2 => crypto::dcrypto::DCRYPTO.handle_wipe_interrupt(),
                     4 => crypto::dcrypto::DCRYPTO.handle_done_interrupt(),
                     5 => crypto::dcrypto::DCRYPTO.handle_receive_interrupt(),
-                    16 | 17 => (*hil::flash::h1b_hw::H1B_HW).program_interrupt(),
 
 //                    54 => (), // KEYMGR HKEY ALERT, ignored
                     104...109 => crypto::aes::KEYMGR0_AES.handle_interrupt(nvic_num),

--- a/h1b/src/hil/flash/driver.rs
+++ b/h1b/src/hil/flash/driver.rs
@@ -64,7 +64,7 @@ impl<'d, A: Alarm, H: Hardware<'d>> Flash<'d, A, H> {
     /// Erases the specified flash page, setting it to all ones.
     pub fn erase(&self, page: usize) -> ReturnCode {
         if self.program_in_progress() { return ReturnCode::EBUSY; }
-        self.smart_program(ERASE_OPCODE, 45, 512 * page, 1);
+        self.smart_program(ERASE_OPCODE, 45, page * super::WORDS_PER_PAGE, 1);
         ReturnCode::SUCCESS
     }
 

--- a/h1b/src/hil/flash/h1b_hw.rs
+++ b/h1b/src/hil/flash/h1b_hw.rs
@@ -261,6 +261,10 @@ impl super::hardware::Hardware<'static> for H1bHw {
 
 	fn set_transaction(&self, offset: usize, size: usize) {
 		use self::TransactionParameters::{Offset,Size};
+		// The offset is relative to the beginning of the flash module. There
+		// are 128 pages per flash module.
+		// TODO(jrvanwhy): Assumes the read is from the second flash bank.
+		let offset = offset - 128 * super::WORDS_PER_PAGE;
 		self.transaction_parameters.write(Offset.val(offset as u32) + Size.val(size as u32));
 	}
 

--- a/h1b/src/hil/flash/hardware.rs
+++ b/h1b/src/hil/flash/hardware.rs
@@ -14,7 +14,7 @@
 
 /// The interface between the flash driver and the (real or fake) flash module.
 
-pub trait Hardware<'a> {
+pub trait Hardware {
 	/// Returns true if an operation is running, false otherwise.
 	fn is_programming(&self) -> bool;
 
@@ -24,10 +24,6 @@ pub trait Hardware<'a> {
 
 	/// Reads the flash error code.
 	fn read_error(&self) -> u16;
-
-	/// Sets the client (the job receiving interrupts from the underlying
-	/// hardware).
-	fn set_client(&self, client: &'a Client);
 
 	/// Set flash transaction parameters (word offset and size). The word offset
 	/// is relative to the start of flash and the size is one less than the
@@ -40,9 +36,4 @@ pub trait Hardware<'a> {
 
 	/// Kick off a smart program execution.
 	fn trigger(&self, opcode: u32);
-}
-
-pub trait Client {
-	/// Called when a flash programming operation completes.
-	fn interrupt(&self);
 }

--- a/h1b/src/hil/flash/mod.rs
+++ b/h1b/src/hil/flash/mod.rs
@@ -24,7 +24,7 @@ mod hardware;
 pub mod smart_program;
 
 #[cfg(feature = "test")]
-pub type Flash<'h, A> = self::driver::Flash<'h, A, self::fake::FakeHw<'h>>;
+pub type Flash<'h, A> = self::driver::Flash<'h, A, self::fake::FakeHw>;
 
  #[cfg(not(feature = "test"))]
 pub type Flash<'h, A> = self::driver::Flash<'static, A, self::h1b_hw::H1bHw>;

--- a/h1b/src/hil/flash/mod.rs
+++ b/h1b/src/hil/flash/mod.rs
@@ -31,3 +31,6 @@ pub type Flash<'h, A> = self::driver::Flash<'static, A, self::h1b_hw::H1bHw>;
 
 pub use self::driver::Client;
 pub use self::hardware::Hardware;
+
+// Constants used by multiple submodules.
+const WORDS_PER_PAGE: usize = 512;

--- a/userspace/h1b_tests/src/hil/flash/fake.rs
+++ b/userspace/h1b_tests/src/hil/flash/fake.rs
@@ -31,6 +31,11 @@ fn fake_hw() -> bool {
 	fake.set_write_data(&[0xFFFF0FFF, 0xFFFAFFFF]);
 	fake.trigger(h1b::hil::flash::driver::WRITE_OPCODE);
 	require!(fake.is_programming() == true);
+	fake.inject_result(0);
+	require!(fake.is_programming() == false);
+	require!(fake.read_error() == 0);
+	fake.trigger(h1b::hil::flash::driver::WRITE_OPCODE);
+	require!(fake.is_programming() == true);
 	fake.finish_operation();
 	require!(fake.read_error() == 0);
 	require!(fake.is_programming() == false);
@@ -44,7 +49,7 @@ fn fake_hw() -> bool {
 	fake.set_write_data(&[0xFFFF00FF, 0xFFAAFFFF]);
 	fake.trigger(h1b::hil::flash::driver::WRITE_OPCODE);
 	require!(fake.is_programming() == true);
-	fake.inject_error(0x8);  // Program failed
+	fake.inject_result(0x8);  // Program failed
 	require!(fake.read_error() == 0x8);
 	require!(fake.is_programming() == false);
 	require!(fake.read(512) == 0xFFFFFFFF);
@@ -56,6 +61,11 @@ fn fake_hw() -> bool {
 	// overlap to the next word.
 	fake.set_transaction(1300, 1 - 1);
 	fake.set_write_data(&[0xFFFFC0FF]);
+	fake.trigger(h1b::hil::flash::driver::WRITE_OPCODE);
+	require!(fake.is_programming() == true);
+	fake.inject_result(0);
+	require!(fake.is_programming() == false);
+	require!(fake.read_error() == 0);
 	fake.trigger(h1b::hil::flash::driver::WRITE_OPCODE);
 	require!(fake.is_programming() == true);
 	fake.finish_operation();

--- a/userspace/h1b_tests/src/hil/flash/mock_alarm.rs
+++ b/userspace/h1b_tests/src/hil/flash/mock_alarm.rs
@@ -29,7 +29,7 @@ impl MockAlarm {
 
 #[cfg(test)]
 impl kernel::hil::time::Time for MockAlarm {
-	type Frequency = kernel::hil::time::Freq1KHz;
+	type Frequency = kernel::hil::time::Freq16MHz;
 	fn disable(&self) { self.setpoint.set(None); }
 	fn is_armed(&self) -> bool { self.setpoint.get().is_some() }
 }

--- a/userspace/h1b_tests/src/hil/flash/smart_program.rs
+++ b/userspace/h1b_tests/src/hil/flash/smart_program.rs
@@ -12,9 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use h1b::hil::flash::driver::WRITE_OPCODE;
+use h1b::hil::flash::{Hardware,smart_program};
+use kernel::hil::time::{Alarm,Frequency,Time};
+use super::mock_alarm::MockAlarm;
+use test::require;
+
 #[test]
 fn decode_error() -> bool {
-	use { h1b::hil::flash::smart_program, test::require };
 	require!(smart_program::decode_error(0b100000000101001) == kernel::ReturnCode::FAIL);
 	require!(smart_program::decode_error(0b100000000000010) == kernel::ReturnCode::ESIZE);
 	require!(smart_program::decode_error(0b000000000001000) == kernel::ReturnCode::FAIL);
@@ -23,48 +28,41 @@ fn decode_error() -> bool {
 
 #[test]
 fn div_round_up() -> bool {
-	use { h1b::hil::flash::smart_program, test::require };
 	require!(smart_program::div_round_up(0, 1) == 0);
 	require!(smart_program::div_round_up(1, 1) == 1);
 	require!(smart_program::div_round_up(3, 2) == 2);
 	require!(smart_program::div_round_up(4, 2) == 2);
-	require!(smart_program::div_round_up(0, core::u32::MAX) == 0);
-	require!(smart_program::div_round_up(core::u32::MAX, core::u32::MAX) == 1);
-	require!(smart_program::div_round_up(core::u32::MAX - 5, core::u32::MAX) == 1);
-	require!(smart_program::div_round_up(core::u32::MAX, core::u32::MAX) == 1);
+	require!(smart_program::div_round_up(0, core::u64::MAX) == 0);
+	require!(smart_program::div_round_up(core::u64::MAX, core::u64::MAX) == 1);
+	require!(smart_program::div_round_up(core::u64::MAX - 5, core::u64::MAX) == 1);
+	require!(smart_program::div_round_up(core::u64::MAX, core::u64::MAX) == 1);
 	true
 }
 
 #[test]
 fn successful_program() -> bool {
-	use h1b::hil::flash::driver::WRITE_OPCODE;
-	use h1b::hil::flash::Hardware;
-	use kernel::hil::time::Alarm;
-	use test::require;
-
-	let alarm = crate::hil::flash::mock_alarm::MockAlarm::new();
+	let alarm = MockAlarm::new();
 	let hw = h1b::hil::flash::fake::FakeHw::new();
 	hw.set_transaction(1300, 1);
 	hw.set_write_data(&[0xFFFF0FFF]);
 
 	// First attempt.
-	let mut state = h1b::hil::flash::smart_program::SmartProgramState::init(9);
-	state = state.step(&alarm, &hw, WRITE_OPCODE, /*is_timeout:*/ false);
-	require!(alarm.get_alarm() == alarm.now() + 150);
+	let mut state = smart_program::SmartProgramState::init(8, true, 100_000_000);
+	state = state.step(&alarm, &hw, WRITE_OPCODE);
+	require!(alarm.get_alarm() == alarm.now() + <MockAlarm as Time>::Frequency::frequency()/10);
 	require!(hw.is_programming() == true);
 	require!(state.return_code() == None);
-	alarm.set_time(50);
-
-	// Inject a spurious interrupt.
-	state = state.step(&alarm, &hw, WRITE_OPCODE, /*is_timeout:*/ false);
-	require!(alarm.get_alarm() == 150);
-	require!(hw.is_programming() == true);
-	require!(state.return_code() == None);
-	alarm.set_time(100);
-	hw.finish_operation();
 
 	// Finish.
-	state = state.step(&alarm, &hw, WRITE_OPCODE, /*is_timeout:*/ false);
+	alarm.set_time(<MockAlarm as Time>::Frequency::frequency()/10);
+	hw.inject_result(0);
+	state = state.step(&alarm, &hw, WRITE_OPCODE);
+	require!(alarm.get_alarm() == <MockAlarm as Time>::Frequency::frequency()/5);
+	require!(hw.is_programming() == true);
+	require!(state.return_code() == None);
+	alarm.set_time(<MockAlarm as Time>::Frequency::frequency()/5);
+	hw.finish_operation();
+	state = state.step(&alarm, &hw, WRITE_OPCODE);
 	require!(alarm.get_alarm() == 0);
 	require!(hw.is_programming() == false);
 	require!(state.return_code() == Some(kernel::ReturnCode::SUCCESS));
@@ -73,35 +71,36 @@ fn successful_program() -> bool {
 
 #[test]
 fn retries() -> bool {
-	use h1b::hil::flash::driver::WRITE_OPCODE;
-	use h1b::hil::flash::Hardware;
-	use kernel::hil::time::Alarm;
-	use test::require;
-
-	let alarm = crate::hil::flash::mock_alarm::MockAlarm::new();
+	let alarm = MockAlarm::new();
 	let hw = h1b::hil::flash::fake::FakeHw::new();
 	hw.set_transaction(1300, 1);
 	hw.set_write_data(&[0xFFFF0FFF]);
 
 	// First programming attempt.
-	let mut state = h1b::hil::flash::smart_program::SmartProgramState::init(9);
-	state = state.step(&alarm, &hw, WRITE_OPCODE, /*is_timeout:*/ false);
-	require!(alarm.get_alarm() == alarm.now() + 150);
+	let mut state = smart_program::SmartProgramState::init(8, true, 100_000_000);
+	state = state.step(&alarm, &hw, WRITE_OPCODE);
+	require!(alarm.get_alarm() == alarm.now() + <MockAlarm as Time>::Frequency::frequency()/10);
 	require!(hw.is_programming() == true);
 	require!(state.return_code() == None);
-	alarm.set_time(100);
-	hw.inject_error(0b100);
+	alarm.set_time(<MockAlarm as Time>::Frequency::frequency()/10);
+	hw.inject_result(0b100);
 
 	// Second attempt.
-	state = state.step(&alarm, &hw, WRITE_OPCODE, /*is_timeout:*/ false);
-	require!(alarm.get_alarm() == alarm.now() + 150);
+	state = state.step(&alarm, &hw, WRITE_OPCODE);
+	require!(alarm.get_alarm() == alarm.now() + <MockAlarm as Time>::Frequency::frequency()/10);
 	require!(hw.is_programming() == true);
 	require!(state.return_code() == None);
-	alarm.set_time(200);
-	hw.finish_operation();
+	alarm.set_time(<MockAlarm as Time>::Frequency::frequency()/5);
+	hw.inject_result(0);
 
 	// Finish.
-	state = state.step(&alarm, &hw, WRITE_OPCODE, /*is_timeout:*/ false);
+	state = state.step(&alarm, &hw, WRITE_OPCODE);
+	require!(alarm.get_alarm() == 3*<MockAlarm as Time>::Frequency::frequency()/10);
+	require!(hw.is_programming() == true);
+	require!(state.return_code() == None);
+	alarm.set_time(3*<MockAlarm as Time>::Frequency::frequency()/10);
+	hw.finish_operation();
+	state = state.step(&alarm, &hw, WRITE_OPCODE);
 	require!(alarm.get_alarm() == 0);
 	require!(hw.is_programming() == false);
 	require!(state.return_code() == Some(kernel::ReturnCode::SUCCESS));
@@ -111,28 +110,24 @@ fn retries() -> bool {
 /// Keep throwing errors until the max retry count.
 #[test]
 fn failed() -> bool {
-	use h1b::hil::flash::driver::WRITE_OPCODE;
-	use h1b::hil::flash::Hardware;
-	use kernel::hil::time::Alarm;
-	use test::require;
-
-	let alarm = crate::hil::flash::mock_alarm::MockAlarm::new();
+	let alarm = MockAlarm::new();
 	let hw = h1b::hil::flash::fake::FakeHw::new();
 	hw.set_transaction(1300, 1);
 	hw.set_write_data(&[0xFFFF0FFF]);
-	let mut state = h1b::hil::flash::smart_program::SmartProgramState::init(9);
+	let mut state = smart_program::SmartProgramState::init(8, true, 100_000_000);
 
-	for i in 0..9 {
-		alarm.set_time(100 * i);
-		state = state.step(&alarm, &hw, WRITE_OPCODE, /*is_timeout:*/ false);
-		require!(alarm.get_alarm() == alarm.now() + 150);
+	for i in 0..8 {
+		alarm.set_time(i * <MockAlarm as Time>::Frequency::frequency()/10);
+		state = state.step(&alarm, &hw, WRITE_OPCODE);
+		require!(alarm.get_alarm() ==
+		         alarm.now() + <MockAlarm as Time>::Frequency::frequency()/10);
 		require!(hw.is_programming() == true);
 		require!(state.return_code() == None);
-		hw.inject_error(0b100);
+		hw.inject_result(0b100);
 	}
 
 	// Finish.
-	state = state.step(&alarm, &hw, WRITE_OPCODE, /*is_timeout:*/ false);
+	state = state.step(&alarm, &hw, WRITE_OPCODE);
 	require!(alarm.get_alarm() == 0);
 	require!(hw.is_programming() == false);
 	require!(state.return_code() == Some(kernel::ReturnCode::FAIL));
@@ -141,31 +136,22 @@ fn failed() -> bool {
 
 #[test]
 fn timeout() -> bool {
-	use h1b::hil::flash::driver::WRITE_OPCODE;
-	use h1b::hil::flash::Hardware;
-	use kernel::hil::time::Alarm;
-	use test::require;
-
-	let alarm = crate::hil::flash::mock_alarm::MockAlarm::new();
+	let alarm = MockAlarm::new();
 	let hw = h1b::hil::flash::fake::FakeHw::new();
 	hw.set_transaction(1300, 1);
 	hw.set_write_data(&[0xFFFF0FFF]);
 
 	// First programming attempt.
-	let mut state = h1b::hil::flash::smart_program::SmartProgramState::init(9);
-	state = state.step(&alarm, &hw, WRITE_OPCODE, /*is_timeout:*/ false);
-	require!(alarm.get_alarm() == alarm.now() + 150);
+	let mut state = smart_program::SmartProgramState::init(8, true, 100_000_000);
+	state = state.step(&alarm, &hw, WRITE_OPCODE);
+	require!(alarm.get_alarm() == alarm.now() + <MockAlarm as Time>::Frequency::frequency()/10);
 	require!(hw.is_programming() == true);
 	require!(state.return_code() == None);
 
-	// Timeout: reset hardware and advance the time.
-	hw.inject_error(0);
-	alarm.set_time(200);
-
 	// Alarm trigger.
-	state = state.step(&alarm, &hw, WRITE_OPCODE, /*is_timeout:*/ true);
+	alarm.set_time(<MockAlarm as Time>::Frequency::frequency()/10);
+	state = state.step(&alarm, &hw, WRITE_OPCODE);
 	require!(alarm.get_alarm() == 0);
-	require!(hw.is_programming() == false);
 	require!(state.return_code() == Some(kernel::ReturnCode::FAIL));
 	true
 }

--- a/userspace/h1b_tests/src/lib.rs
+++ b/userspace/h1b_tests/src/lib.rs
@@ -14,6 +14,11 @@
 
 #![no_std]
 
+// Rust complains that things are unused if they are only used when cfg(test) is
+// true. If we include modules when cfg(test) is false, then declarations in the
+// modules need to be marked #[cfg(test)]. Instead, we simply do not include the
+// code in other configs.
+#[cfg(test)]
 mod hil;
 
 #[test]


### PR DESCRIPTION
1. Moved to timeout-based operation rather than interrupt-based
   operation due to b/138842998.
2. Add the final programming pulse needed for write operations.

Commits new in this PR:
1. Flash driver fixes. ...

```
----------------------
`make prtest` summary:
----------------------
git rev-parse HEAD
0becf1dc0afba8bde1d8b8d8bc9ebe629bd72c03
git status
On branch flash-fixes
Your branch is up to date with 'origin/flash-fixes'.

nothing to commit, working tree clean
```