### PR TITLE
Give the Flash driver API its own trait.

### DIFF
--- a/golf2/src/flash_test.rs
+++ b/golf2/src/flash_test.rs
@@ -12,19 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use ::kernel::hil::time::Alarm;
 use ::kernel::ReturnCode;
 use ::h1b::hil::flash::Flash;
 
 /// Test tool for the flash driver -- runs test cases using the provided driver.
 /// Used for integration testing against the real hardware. Will set itself as
 /// the flash driver's client.
-pub struct FlashTest<A: Alarm + 'static> {
-    driver: &'static Flash<'static, A>,
+pub struct FlashTest<F: Flash<'static> + 'static> {
+    driver: &'static F,
     state: ::core::cell::Cell<Option<Tests>>,
 }
 
-impl<A: Alarm> ::h1b::hil::flash::Client for FlashTest<A> {
+impl<F: Flash<'static> + 'static> ::h1b::hil::flash::Client for FlashTest<F> {
     fn erase_done(&self, code: ReturnCode) {
         match self.state.take() {
             None => println!("FlashTest FAIL: erase_done() w/ state == None"),
@@ -46,11 +45,11 @@ impl<A: Alarm> ::h1b::hil::flash::Client for FlashTest<A> {
     }
 }
 
-impl<A: Alarm + 'static> FlashTest<A> {
+impl<F: Flash<'static> + 'static> FlashTest<F> {
     const TEST_PAGE: usize = 255;
     const TEST_WORD: usize = 512 * Self::TEST_PAGE;
 
-    pub fn new(driver: &'static Flash<'static, A>) -> Self {
+    pub fn new(driver: &'static F) -> Self {
         FlashTest { driver, state: ::core::cell::Cell::new(None) }
     }
 

--- a/golf2/src/main.rs
+++ b/golf2/src/main.rs
@@ -234,8 +234,8 @@ pub unsafe fn reset_handler() {
     let flash_virtual_alarm = static_init!(VirtualMuxAlarm<'static, Timels<'static>>,
                                            VirtualMuxAlarm::new(alarm_mux));
     let flash = static_init!(
-        h1b::hil::flash::Flash<'static, VirtualMuxAlarm<'static, Timels<'static>>>,
-        h1b::hil::flash::Flash::new(flash_virtual_alarm, &*h1b::hil::flash::h1b_hw::H1B_HW));
+        h1b::hil::flash::FlashImpl<'static, VirtualMuxAlarm<'static, Timels<'static>>>,
+        h1b::hil::flash::FlashImpl::new(flash_virtual_alarm, &*h1b::hil::flash::h1b_hw::H1B_HW));
     flash_virtual_alarm.set_client(flash);
 
     let timer_virtual_alarm = static_init!(VirtualMuxAlarm<'static, Timels<'static>>,
@@ -386,8 +386,11 @@ pub unsafe fn reset_handler() {
 
     #[allow(unused)]
     let flash_test = static_init!(
-        flash_test::FlashTest<VirtualMuxAlarm<'static, Timels<'static>>>,
-        flash_test::FlashTest::<VirtualMuxAlarm<'static, Timels<'static>>>::new(flash));
+        flash_test::FlashTest<
+            h1b::hil::flash::FlashImpl<'static, VirtualMuxAlarm<'static, Timels<'static>>>>,
+        flash_test::FlashTest::<
+            h1b::hil::flash::FlashImpl<'static,
+                                       VirtualMuxAlarm<'static, Timels<'static>>>>::new(flash));
 
     // dcrypto_test::run_dcrypto();
     //    rng_test::run_rng();

--- a/h1b/src/hil/flash/flash.rs
+++ b/h1b/src/hil/flash/flash.rs
@@ -1,0 +1,38 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use ::kernel::ReturnCode;
+
+/// Flash client -- receives callbacks when flash operations complete.
+pub trait Client {
+	fn erase_done(&self, ReturnCode);
+	fn write_done(&self, ReturnCode);
+}
+
+/// Flash driver API.
+pub trait Flash<'d> {
+	/// Erases the specified flash page, setting it to all ones.
+	fn erase(&self, page: usize) -> ReturnCode;
+
+	/// Reads the given word from flash.
+	fn read(&self, word: usize) -> u32;
+
+	/// Writes a buffer (of up to 32 words) into the given location in flash.
+	/// The target location is specified as an offset from the beginning of
+	/// flash in units of words.
+	fn write(&self, target: usize, data: &[u32]) -> ReturnCode;
+
+	/// Links this driver to its client.
+	fn set_client(&self, client: &'d Client);
+}

--- a/h1b/src/hil/flash/mod.rs
+++ b/h1b/src/hil/flash/mod.rs
@@ -19,17 +19,18 @@
 pub mod driver;
 #[cfg(feature = "test")]
 pub mod fake;
+pub mod flash;
 pub mod h1b_hw;
 mod hardware;
 pub mod smart_program;
 
 #[cfg(feature = "test")]
-pub type Flash<'h, A> = self::driver::Flash<'h, A, self::fake::FakeHw>;
+pub type FlashImpl<'h, A> = self::driver::FlashImpl<'h, A, self::fake::FakeHw>;
 
  #[cfg(not(feature = "test"))]
-pub type Flash<'h, A> = self::driver::Flash<'static, A, self::h1b_hw::H1bHw>;
+pub type FlashImpl<'h, A> = self::driver::FlashImpl<'static, A, self::h1b_hw::H1bHw>;
 
-pub use self::driver::Client;
+pub use self::flash::{Client,Flash};
 pub use self::hardware::Hardware;
 
 // Constants used by multiple submodules.

--- a/userspace/h1b_tests/src/hil/flash/driver.rs
+++ b/userspace/h1b_tests/src/hil/flash/driver.rs
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(test)]
-use { h1b::hil::flash::Hardware, kernel::hil::time::Alarm, test::require };
+use h1b::hil::flash::{Flash,Hardware};
+use kernel::hil::time::Alarm;
+use test::require;
 
 // These are in counts of a 16 MHz clock.
 #[cfg(test)]
@@ -61,7 +62,7 @@ fn erase() -> bool {
 	let hw = h1b::hil::flash::fake::FakeHw::new();
 
 	// First attempt.
-	let driver = unsafe { h1b::hil::flash::Flash::new(&alarm, &hw) };
+	let driver = unsafe { h1b::hil::flash::FlashImpl::new(&alarm, &hw) };
 	driver.set_client(&client);
 	require!(driver.erase(2) == kernel::ReturnCode::SUCCESS);
 	require!(alarm.get_alarm() == alarm.now() + ERASE_TIME);
@@ -95,7 +96,7 @@ fn erase_max_retries() -> bool {
 	let alarm = crate::hil::flash::mock_alarm::MockAlarm::new();
 	let client = MockClient::new();
 	let hw = h1b::hil::flash::fake::FakeHw::new();
-	let driver = unsafe { h1b::hil::flash::Flash::new(&alarm, &hw) };
+	let driver = unsafe { h1b::hil::flash::FlashImpl::new(&alarm, &hw) };
 	driver.set_client(&client);
 	require!(driver.erase(2) == kernel::ReturnCode::SUCCESS);
 	require!(alarm.get_alarm() == alarm.now() + ERASE_TIME);
@@ -132,7 +133,7 @@ fn write_then_erase() -> bool {
 	let hw = h1b::hil::flash::fake::FakeHw::new();
 
 	// Write
-	let driver = unsafe { h1b::hil::flash::Flash::new(&alarm, &hw) };
+	let driver = unsafe { h1b::hil::flash::FlashImpl::new(&alarm, &hw) };
 	driver.set_client(&client);
 	require!(driver.write(1300, &[0xFFFFABCD]) == kernel::ReturnCode::SUCCESS);
 	require!(alarm.get_alarm() == alarm.now() + WRITE_WORD_TIME);
@@ -152,7 +153,7 @@ fn write_then_erase() -> bool {
 	require!(driver.read(1300) == 0xFFFFABCD);
 
 	// Erase
-	let driver = unsafe { h1b::hil::flash::Flash::new(&alarm, &hw) };
+	let driver = unsafe { h1b::hil::flash::FlashImpl::new(&alarm, &hw) };
 	driver.set_client(&client);
 	require!(driver.erase(2) == kernel::ReturnCode::SUCCESS);
 	require!(alarm.get_alarm() == alarm.now() + ERASE_TIME);
@@ -177,7 +178,7 @@ fn successful_program() -> bool {
 	let hw = h1b::hil::flash::fake::FakeHw::new();
 
 	// First attempt.
-	let driver = unsafe { h1b::hil::flash::Flash::new(&alarm, &hw) };
+	let driver = unsafe { h1b::hil::flash::FlashImpl::new(&alarm, &hw) };
 	driver.set_client(&client);
 	require!(driver.write(1300, &[0xFFFFABCD]) == kernel::ReturnCode::SUCCESS);
 	require!(alarm.get_alarm() == alarm.now() + WRITE_WORD_TIME);
@@ -219,7 +220,7 @@ fn timeout() -> bool {
 	hw.set_write_data(&[0xFFFF0FFF]);
 
 	// First attempt.
-	let driver = unsafe { h1b::hil::flash::Flash::new(&alarm, &hw) };
+	let driver = unsafe { h1b::hil::flash::FlashImpl::new(&alarm, &hw) };
 	driver.set_client(&client);
 	require!(driver.write(1300, &[0xFFFFABCD]) == kernel::ReturnCode::SUCCESS);
 	require!(alarm.get_alarm() == alarm.now() + WRITE_WORD_TIME);
@@ -241,7 +242,7 @@ fn write_max_retries() -> bool {
 	let alarm = crate::hil::flash::mock_alarm::MockAlarm::new();
 	let client = MockClient::new();
 	let hw = h1b::hil::flash::fake::FakeHw::new();
-	let driver = unsafe { h1b::hil::flash::Flash::new(&alarm, &hw) };
+	let driver = unsafe { h1b::hil::flash::FlashImpl::new(&alarm, &hw) };
 	driver.set_client(&client);
 	require!(driver.write(1300, &[0xFFFFABCD]) == kernel::ReturnCode::SUCCESS);
 	require!(alarm.get_alarm() == alarm.now() + WRITE_WORD_TIME);


### PR DESCRIPTION
This prevents the flash driver's dependencies from propagating into NvCounter when NvCounter is added.

```
----------------------
`make prtest` summary:
----------------------
git rev-parse HEAD
c6b537abd7f57a97cb4388482c2d2f85fdf8df86
git status
On branch flash-trait
Your branch is up to date with 'origin/flash-trait'.

nothing to commit, working tree clean
```