### PR TITLE
Check bounds of offset on flash operations.

### DIFF
--- a/golf2/src/flash_test.rs
+++ b/golf2/src/flash_test.rs
@@ -70,8 +70,15 @@ impl<F: Flash<'static> + 'static> FlashTest<F> {
     fn erase1_done(&self, code: ReturnCode) {
         println!("FlashTest: Erase1 done. code: {:?}", code);
         let read_value = self.driver.read(Self::TEST_WORD);
-        if read_value != 0xFFFFFFFF {
-            println!("FlashTest: Erase1 failed, value: {}", read_value);
+        match read_value {
+            ReturnCode::SuccessWithValue {value: val} => {
+                if val != 0xFFFFFFFF {
+                    println!("FlashTest: Erase1 failed, value: {}", val);
+                }
+            },
+            _ => {
+                println!("FlashTest: erase test read failed: {:?}", read_value);
+            }
         }
         self.write1_start();
     }
@@ -85,8 +92,15 @@ impl<F: Flash<'static> + 'static> FlashTest<F> {
     fn write1_done(&self, code: ReturnCode) {
         println!("FlashTest: Write1 done. code: {:?}", code);
         let read_value = self.driver.read(Self::TEST_WORD);
-        if read_value != 0x0000FFFF {
-            println!("FlashTest: Write1 failed, value: {}", read_value);
+        match read_value {
+            ReturnCode::SuccessWithValue{value: val} => {
+                if val != 0x0000FFFF {
+                    println!("FlashTest: Write1 failed, value: {}", val);
+                }
+            },
+            _ => {
+                println!("FlashTest: read failed: {:?}", read_value);
+            }
         }
         self.write2_start();
     }
@@ -100,8 +114,15 @@ impl<F: Flash<'static> + 'static> FlashTest<F> {
     fn write2_done(&self, code: ReturnCode) {
         println!("FlashTest: Write2 done. code: {:?}", code);
         let read_value = self.driver.read(Self::TEST_WORD);
-        if read_value != 0x00000000 {
-            println!("FlashTest: Write2 failed, value: {}", read_value);
+        match read_value {
+            ReturnCode::SuccessWithValue{value: val} => {
+                if val != 0x00000000 {
+                    println!("FlashTest: Write2 failed, value: {}", val);
+                }
+            },
+            _ => {
+                println!("FlashTest: read failed: {:?}", read_value);
+            }
         }
         self.erase2_start();
     }
@@ -114,8 +135,15 @@ impl<F: Flash<'static> + 'static> FlashTest<F> {
     fn erase2_done(&self, code: ReturnCode) {
         println!("FlashTest: Erase2 done. code: {:?}", code);
         let read_value = self.driver.read(Self::TEST_WORD);
-        if read_value != 0xFFFFFFFF {
-            println!("FlashTest: Erase2 failed, value: {}", read_value);
+        match read_value {
+            ReturnCode::SuccessWithValue{value: val} => {
+                if val != 0xFFFFFFFF {
+                    println!("FlashTest: Erase2 failed, value: {}", val);
+                }
+            },
+            _ => {
+                println!("FlashTest: Erase2 read failed: {:?}", read_value);
+            }
         }
     }
 }

--- a/h1b/src/hil/flash/driver.rs
+++ b/h1b/src/hil/flash/driver.rs
@@ -61,7 +61,7 @@ impl<'d, A: Alarm, H: Hardware> super::flash::Flash<'d> for FlashImpl<'d, A, H> 
         ReturnCode::SUCCESS
     }
 
-    fn read(&self, word: usize) -> u32 {
+    fn read(&self, word: usize) -> ReturnCode {
         self.hw.read(word)
     }
 

--- a/h1b/src/hil/flash/flash.rs
+++ b/h1b/src/hil/flash/flash.rs
@@ -16,23 +16,25 @@ use ::kernel::ReturnCode;
 
 /// Flash client -- receives callbacks when flash operations complete.
 pub trait Client {
-	fn erase_done(&self, ReturnCode);
-	fn write_done(&self, ReturnCode);
+        fn erase_done(&self, ReturnCode);
+        fn write_done(&self, ReturnCode);
 }
 
 /// Flash driver API.
 pub trait Flash<'d> {
-	/// Erases the specified flash page, setting it to all ones.
-	fn erase(&self, page: usize) -> ReturnCode;
+        /// Erases the specified flash page, setting it to all ones.
+        fn erase(&self, page: usize) -> ReturnCode;
 
-	/// Reads the given word from flash.
-	fn read(&self, word: usize) -> u32;
+        /// Reads the given word from flash. Successful read returns
+        /// ReturnCode::SuccessWithValue with the value read; if the
+        /// offset is out of bounds, returns ReturnCode::ESIZE.
+        fn read(&self, offset: usize) -> ReturnCode;
 
-	/// Writes a buffer (of up to 32 words) into the given location in flash.
-	/// The target location is specified as an offset from the beginning of
-	/// flash in units of words.
-	fn write(&self, target: usize, data: &[u32]) -> ReturnCode;
+        /// Writes a buffer (of up to 32 words) into the given location in flash.
+        /// The target location is specified as an offset from the beginning of
+        /// flash in units of words.
+        fn write(&self, target: usize, data: &[u32]) -> ReturnCode;
 
-	/// Links this driver to its client.
-	fn set_client(&self, client: &'d Client);
+        /// Links this driver to its client.
+        fn set_client(&self, client: &'d Client);
 }

--- a/h1b/src/hil/flash/h1b_hw.rs
+++ b/h1b/src/hil/flash/h1b_hw.rs
@@ -14,6 +14,7 @@
 
 #![allow(unused)]
 
+use kernel::ReturnCode;
 use kernel::common::cells::VolatileCell;
 use kernel::common::registers::ReadWrite;
 
@@ -245,13 +246,17 @@ impl super::hardware::Hardware for H1bHw {
                 self.pe_control_1.get() != 0
         }
 
-        fn read(&self, offset: usize) -> u32 {
+        fn read(&self, offset: usize) -> ReturnCode {
             // The two flash macros are in consecutive memory locations, so they can
             // be addressed as one.
             if offset > H1B_FLASH_SIZE {
-                0
+                ReturnCode::ESIZE
             } else {
-                unsafe { ::core::ptr::read_volatile((H1B_FLASH_START as *const u32).add(offset)) }
+                unsafe {
+                    ReturnCode::SuccessWithValue {
+                        value: ::core::ptr::read_volatile((H1B_FLASH_START as *const u32).add(offset)) as usize
+                    }
+                }
             }
         }
 

--- a/h1b/src/hil/flash/h1b_hw.rs
+++ b/h1b/src/hil/flash/h1b_hw.rs
@@ -21,13 +21,13 @@ use kernel::common::registers::ReadWrite;
 // trigger a fault), and should only be manipulated by the flash hardware.
 pub static mut H1B_HW: *const H1bHw = 0x40720000 as *const H1bHw;
 
-const H1B_FLASH_START: usize     = 0x40000;
-const H1B_FLASH_BANK_SIZE: usize = 0x40000;
-const H1B_FLASH_SIZE: usize      = 0x80000; // Two banks
+pub const H1B_FLASH_START: usize     = 0x40000;
+pub const H1B_FLASH_BANK_SIZE: usize = 0x40000;
+pub const H1B_FLASH_SIZE: usize      = 0x80000; // Two banks
 
-const H1B_INFO_0_START: usize    = 0x20000;
-const H1B_INFO_1_START: usize    = 0x28000;
-const H1B_INFO_SIZE: usize       = 0x00800;
+pub const H1B_INFO_0_START: usize    = 0x20000;
+pub const H1B_INFO_1_START: usize    = 0x28000;
+pub const H1B_INFO_SIZE: usize       = 0x00800;
 
 register_bitfields![u32,
         TransactionParameters [

--- a/h1b/src/hil/flash/h1b_hw.rs
+++ b/h1b/src/hil/flash/h1b_hw.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(unused)]
+
 use kernel::common::cells::VolatileCell;
 use kernel::common::registers::ReadWrite;
 
@@ -19,249 +21,265 @@ use kernel::common::registers::ReadWrite;
 // trigger a fault), and should only be manipulated by the flash hardware.
 pub static mut H1B_HW: *const H1bHw = 0x40720000 as *const H1bHw;
 
+const H1B_FLASH_START: usize     = 0x40000;
+const H1B_FLASH_BANK_SIZE: usize = 0x40000;
+const H1B_FLASH_SIZE: usize      = 0x80000; // Two banks
+
+const H1B_INFO_0_START: usize    = 0x20000;
+const H1B_INFO_1_START: usize    = 0x28000;
+const H1B_INFO_SIZE: usize       = 0x00800;
+
 register_bitfields![u32,
-	TransactionParameters [
-		Offset OFFSET(0) NUMBITS(16) [],
-		Bank   OFFSET(16) NUMBITS(1) [],
-		Size   OFFSET(17) NUMBITS(5) []
-	]
+        TransactionParameters [
+                Offset OFFSET(0) NUMBITS(16) [],
+                Bank   OFFSET(16) NUMBITS(1) [],
+                Size   OFFSET(17) NUMBITS(5) []
+        ]
 ];
 
 #[repr(C)]
 pub struct H1bHw {
-	/// Read/Program/Erase control for flash macro 0.
-	_pe_control_0: VolatileCell<u32>,
+        /// Read/Program/Erase control for flash macro 0.
+        _pe_control_0: VolatileCell<u32>,
 
-	/// Read/Program/Erase control for flash macro 1.
-	pe_control_1: VolatileCell<u32>,
+        /// Read/Program/Erase control for flash macro 1.
+        pe_control_1: VolatileCell<u32>,
 
-	/// Write size and offset.
-	transaction_parameters: ReadWrite<u32, TransactionParameters::Register>,
+        /// Write size and offset.
+        transaction_parameters: ReadWrite<u32, TransactionParameters::Register>,
 
-	/// Read/erase/program lockdown modes for the various flash regions.
-	_lockdown_triggers: VolatileCell<u32>,
+        /// Read/erase/program lockdown modes for the various flash regions.
+        _lockdown_triggers: VolatileCell<u32>,
 
-	/// Triggers a read of info 0 data to check for secure data write functionality. Only available
-	/// in test mode.
-	_enable_info0_shadow_read: VolatileCell<u32>,
+        /// Triggers a read of info 0 data to check for secure data write functionality. Only available
+        /// in test mode.
+        _enable_info0_shadow_read: VolatileCell<u32>,
 
-	/// Operation-completion interrupt controls.
-	_interrupt_control: VolatileCell<u32>,
+        /// Operation-completion interrupt controls.
+        _interrupt_control: VolatileCell<u32>,
 
-	/// Operation-completion state. Cleared on read.
-	_interrupt_state: VolatileCell<u32>,
+        /// Operation-completion state. Cleared on read.
+        _interrupt_state: VolatileCell<u32>,
 
-	/// Macro 0 override signal unlock.
-	_override_0_unlock: VolatileCell<u32>,
+        /// Macro 0 override signal unlock.
+        _override_0_unlock: VolatileCell<u32>,
 
-	/// Macro 1 override signal unlock.
-	_override_1_unlock: VolatileCell<u32>,
+        /// Macro 1 override signal unlock.
+        _override_1_unlock: VolatileCell<u32>,
 
-	/// DIN override.
-	_din_override: VolatileCell<u32>,
+        /// DIN override.
+        _din_override: VolatileCell<u32>,
 
-	/// Offset override.
-	_offset_override: VolatileCell<u32>,
+        /// Offset override.
+        _offset_override: VolatileCell<u32>,
 
-	/// Signal override values.
-	_override_signal_values: VolatileCell<u32>,
+        /// Signal override values.
+        _override_signal_values: VolatileCell<u32>,
 
-	/// Signal override controls.
-	_override_signal_control: VolatileCell<u32>,
+        /// Signal override controls.
+        _override_signal_control: VolatileCell<u32>,
 
-	/// Controls whether the system may powerdown without waiting for graceful brownout completion.
-	disable_brownout_wait: VolatileCell<u32>,
+        /// Controls whether the system may powerdown without waiting for graceful brownout completion.
+        disable_brownout_wait: VolatileCell<u32>,
 
-	/// The most recent value of Macro 0's DOUT.
-	dout_value_0: VolatileCell<u32>,
+        /// The most recent value of Macro 0's DOUT.
+        dout_value_0: VolatileCell<u32>,
 
-	/// TC override read value.
-	_tc_override_value_0: VolatileCell<u32>,
+        /// TC override read value.
+        _tc_override_value_0: VolatileCell<u32>,
 
-	/// The most recent value of Macro 1's DOUT.
-	dout_value_1: VolatileCell<u32>,
+        /// The most recent value of Macro 1's DOUT.
+        dout_value_1: VolatileCell<u32>,
 
-	/// TC override read value.
-	_tc_override_value_1: VolatileCell<u32>,
+        /// TC override read value.
+        _tc_override_value_1: VolatileCell<u32>,
 
-	/// Write data buffer.
-	write_data: [VolatileCell<u32>; 32],
+        /// Write data buffer.
+        write_data: [VolatileCell<u32>; 32],
 
-	/// Program and erase enable.
-	program_erase_enable: VolatileCell<u32>,
+        /// Program and erase enable.
+        program_erase_enable: VolatileCell<u32>,
 
-	/// Redundancy remapping enablement and control for macro 0.
-	redundancy_remapping_0: VolatileCell<u32>,
+        /// Redundancy remapping enablement and control for macro 0.
+        redundancy_remapping_0: VolatileCell<u32>,
 
-	/// Redundancy remapping enablement and control for macro 1.
-	redundancy_remapping_1: VolatileCell<u32>,
+        /// Redundancy remapping enablement and control for macro 1.
+        redundancy_remapping_1: VolatileCell<u32>,
 
-	/// Error signalling.
-	error_code: VolatileCell<u32>,
+        /// Error signalling.
+        error_code: VolatileCell<u32>,
 
-	/// Read operation duration.
-	read_cycles: VolatileCell<u32>,
+        /// Read operation duration.
+        read_cycles: VolatileCell<u32>,
 
-	/// The first cycle XE should be asserted during reads.
-	read_xe_first_cycle: VolatileCell<u32>,
+        /// The first cycle XE should be asserted during reads.
+        read_xe_first_cycle: VolatileCell<u32>,
 
-	/// The last cycle XE should be asserted during reads.
-	read_xe_last_cycle: VolatileCell<u32>,
+        /// The last cycle XE should be asserted during reads.
+        read_xe_last_cycle: VolatileCell<u32>,
 
-	/// The first cycle YE should be asserted during reads.
-	read_ye_first_cycle: VolatileCell<u32>,
+        /// The first cycle YE should be asserted during reads.
+        read_ye_first_cycle: VolatileCell<u32>,
 
-	/// The last cycle YE should be asserted during reads.
-	read_ye_last_cycle: VolatileCell<u32>,
+        /// The last cycle YE should be asserted during reads.
+        read_ye_last_cycle: VolatileCell<u32>,
 
-	/// The first cycle SE should be asserted during reads.
-	read_se_first_cycle: VolatileCell<u32>,
+        /// The first cycle SE should be asserted during reads.
+        read_se_first_cycle: VolatileCell<u32>,
 
-	/// The last cycle SE should be asserted during reads.
-	read_se_last_cycle: VolatileCell<u32>,
+        /// The last cycle SE should be asserted during reads.
+        read_se_last_cycle: VolatileCell<u32>,
 
-	/// The first cycle PV should be asserted during program verify reads.
-	read_pv_first_cycle: VolatileCell<u32>,
+        /// The first cycle PV should be asserted during program verify reads.
+        read_pv_first_cycle: VolatileCell<u32>,
 
-	/// The last cycle PV should be asserted during program verify reads.
-	read_pv_last_cycle: VolatileCell<u32>,
+        /// The last cycle PV should be asserted during program verify reads.
+        read_pv_last_cycle: VolatileCell<u32>,
 
-	/// The first cycle EV should be asserted during erase verify reads.
-	read_ev_first_cycle: VolatileCell<u32>,
+        /// The first cycle EV should be asserted during erase verify reads.
+        read_ev_first_cycle: VolatileCell<u32>,
 
-	/// The last cycle EV should be asserted during erase verify reads.
-	read_ev_last_cycle: VolatileCell<u32>,
+        /// The last cycle EV should be asserted during erase verify reads.
+        read_ev_last_cycle: VolatileCell<u32>,
 
-	/// Smart program algorithm enablement.
-	enable_smart_program: VolatileCell<u32>,
+        /// Smart program algorithm enablement.
+        enable_smart_program: VolatileCell<u32>,
 
-	/// Single-word program timing.
-	program_cycles: VolatileCell<u32>,
+        /// Single-word program timing.
+        program_cycles: VolatileCell<u32>,
 
-	/// The first cycle XE should be asserted during program.
-	program_xe_first_cycle: VolatileCell<u32>,
+        /// The first cycle XE should be asserted during program.
+        program_xe_first_cycle: VolatileCell<u32>,
 
-	/// The last cycle XE should be asserted during program.
-	program_xe_last_cycle: VolatileCell<u32>,
+        /// The last cycle XE should be asserted during program.
+        program_xe_last_cycle: VolatileCell<u32>,
 
-	/// The first cycle YE should be asserted during program.
-	program_ye_first_cycle: VolatileCell<u32>,
+        /// The first cycle YE should be asserted during program.
+        program_ye_first_cycle: VolatileCell<u32>,
 
-	/// The last cycle YE should be asserted during program.
-	program_ye_last_cycle: VolatileCell<u32>,
+        /// The last cycle YE should be asserted during program.
+        program_ye_last_cycle: VolatileCell<u32>,
 
-	/// The first cycle DIN and YADR are ready during program.
-	program_din_yadr_first_cycle: VolatileCell<u32>,
+        /// The first cycle DIN and YADR are ready during program.
+        program_din_yadr_first_cycle: VolatileCell<u32>,
 
-	/// The last cycle DIN and YADR are ready during program.
-	program_din_yadr_last_cycle: VolatileCell<u32>,
+        /// The last cycle DIN and YADR are ready during program.
+        program_din_yadr_last_cycle: VolatileCell<u32>,
 
-	/// The first cycle PROG should be asserted during program.
-	program_prog_first_cycle: VolatileCell<u32>,
+        /// The first cycle PROG should be asserted during program.
+        program_prog_first_cycle: VolatileCell<u32>,
 
-	/// The last cycle PROG should be asserted during program.
-	program_prog_last_cycle: VolatileCell<u32>,
+        /// The last cycle PROG should be asserted during program.
+        program_prog_last_cycle: VolatileCell<u32>,
 
-	/// The first cycle NVSTR should be asserted during program.
-	program_nvstr_first_cycle: VolatileCell<u32>,
+        /// The first cycle NVSTR should be asserted during program.
+        program_nvstr_first_cycle: VolatileCell<u32>,
 
-	/// The last cycle NVSTR should be asserted during program.
-	program_nvstr_last_cycle: VolatileCell<u32>,
+        /// The last cycle NVSTR should be asserted during program.
+        program_nvstr_last_cycle: VolatileCell<u32>,
 
-	/// Smart erase algorithm enablement.
-	enable_smart_erase: VolatileCell<u32>,
+        /// Smart erase algorithm enablement.
+        enable_smart_erase: VolatileCell<u32>,
 
-	/// Flash erase cycle count.
-	erase_cycles: VolatileCell<u32>,
+        /// Flash erase cycle count.
+        erase_cycles: VolatileCell<u32>,
 
-	/// The first cycle XE should be asserted during erase.
-	erase_xe_first_cycle: VolatileCell<u32>,
+        /// The first cycle XE should be asserted during erase.
+        erase_xe_first_cycle: VolatileCell<u32>,
 
-	/// The last cycle XE should be asserted during erase.
-	erase_xe_last_cycle: VolatileCell<u32>,
+        /// The last cycle XE should be asserted during erase.
+        erase_xe_last_cycle: VolatileCell<u32>,
 
-	/// The first cycle ERASE should be asserted during erase.
-	erase_erase_first_cycle: VolatileCell<u32>,
+        /// The first cycle ERASE should be asserted during erase.
+        erase_erase_first_cycle: VolatileCell<u32>,
 
-	/// The last cycle ERASE should be asserted during erase.
-	erase_erase_last_cycle: VolatileCell<u32>,
+        /// The last cycle ERASE should be asserted during erase.
+        erase_erase_last_cycle: VolatileCell<u32>,
 
-	/// The first cycle NVSTR should be asserted during erase.
-	erase_nvstr_first_cycle: VolatileCell<u32>,
+        /// The first cycle NVSTR should be asserted during erase.
+        erase_nvstr_first_cycle: VolatileCell<u32>,
 
-	/// The last cycle NVSTR should be asserted during erase.
-	erase_nvstr_last_cycle: VolatileCell<u32>,
+        /// The last cycle NVSTR should be asserted during erase.
+        erase_nvstr_last_cycle: VolatileCell<u32>,
 
-	/// Enable smart erase for bulk erases.
-	enable_bulk_smart_erase: VolatileCell<u32>,
+        /// Enable smart erase for bulk erases.
+        enable_bulk_smart_erase: VolatileCell<u32>,
 
-	/// Duration of bulk erase operations.
-	bulk_erase_cycles: VolatileCell<u32>,
+        /// Duration of bulk erase operations.
+        bulk_erase_cycles: VolatileCell<u32>,
 
-	/// The first cycle XE should be asserted during bulkerase.
-	bulkerase_xe_first_cycle: VolatileCell<u32>,
+        /// The first cycle XE should be asserted during bulkerase.
+        bulkerase_xe_first_cycle: VolatileCell<u32>,
 
-	/// The last cycle XE should be asserted during bulkerase.
-	bulkerase_xe_last_cycle: VolatileCell<u32>,
+        /// The last cycle XE should be asserted during bulkerase.
+        bulkerase_xe_last_cycle: VolatileCell<u32>,
 
-	/// The first cycle BULKERASE should be asserted during bulkerase.
-	bulkerase_bulkerase_first_cycle: VolatileCell<u32>,
+        /// The first cycle BULKERASE should be asserted during bulkerase.
+        bulkerase_bulkerase_first_cycle: VolatileCell<u32>,
 
-	/// The last cycle BULKERASE should be asserted during bulkerase.
-	bulkerase_bulkerase_last_cycle: VolatileCell<u32>,
+        /// The last cycle BULKERASE should be asserted during bulkerase.
+        bulkerase_bulkerase_last_cycle: VolatileCell<u32>,
 
-	/// The first cycle MAS1 should be asserted during bulkerase.
-	bulkerase_mas1_first_cycle: VolatileCell<u32>,
+        /// The first cycle MAS1 should be asserted during bulkerase.
+        bulkerase_mas1_first_cycle: VolatileCell<u32>,
 
-	/// The last cycle MAS1 should be asserted during bulkerase.
-	bulkerase_mas1_last_cycle: VolatileCell<u32>,
+        /// The last cycle MAS1 should be asserted during bulkerase.
+        bulkerase_mas1_last_cycle: VolatileCell<u32>,
 
-	/// The first cycle NVSTR should be asserted during bulkerase.
-	bulkerase_nvstr_first_cycle: VolatileCell<u32>,
+        /// The first cycle NVSTR should be asserted during bulkerase.
+        bulkerase_nvstr_first_cycle: VolatileCell<u32>,
 
-	/// The last cycle NVSTR should be asserted during bulkerase.
-	bulkerase_nvstr_last_cycle: VolatileCell<u32>,
+        /// The last cycle NVSTR should be asserted during bulkerase.
+        bulkerase_nvstr_last_cycle: VolatileCell<u32>,
 
-	/// Controller debug signals.
-	debug_signals: VolatileCell<u32>,
+        /// Controller debug signals.
+        debug_signals: VolatileCell<u32>,
 
-	// The integration test controls are omitted because they are unnecessary
-	// and are after a large address space gap.
+        // The integration test controls are omitted because they are unnecessary
+        // and are after a large address space gap.
 }
 
 impl super::hardware::Hardware for H1bHw {
-	fn is_programming(&self) -> bool {
-		// TODO(jrvanwhy): Only checks the second flash bank.
-		self.pe_control_1.get() != 0
-	}
+        fn is_programming(&self) -> bool {
+                // TODO(jrvanwhy): Only checks the second flash bank.
+                self.pe_control_1.get() != 0
+        }
 
-	fn read(&self, offset: usize) -> u32 {
-		// The two flash macros are in consecutive memory locations, so they can
-		// be addressed as one.
-		unsafe { ::core::ptr::read_volatile((0x40000 as *const u32).add(offset)) }
-	}
+        fn read(&self, offset: usize) -> u32 {
+            // The two flash macros are in consecutive memory locations, so they can
+            // be addressed as one.
+            if offset > H1B_FLASH_SIZE {
+                0
+            } else {
+                unsafe { ::core::ptr::read_volatile((H1B_FLASH_START as *const u32).add(offset)) }
+            }
+        }
 
-	fn read_error(&self) -> u16 {
-		self.error_code.get() as u16
-	}
+        fn read_error(&self) -> u16 {
+                self.error_code.get() as u16
+        }
 
-	fn set_transaction(&self, offset: usize, size: usize) {
-		use self::TransactionParameters::{Offset,Size};
-		// The offset is relative to the beginning of the flash module. There
-		// are 128 pages per flash module.
-		// TODO(jrvanwhy): Assumes the read is from the second flash bank.
-		let offset = offset - 128 * super::WORDS_PER_PAGE;
-		self.transaction_parameters.write(Offset.val(offset as u32) + Size.val(size as u32));
-	}
+        fn set_transaction(&self, offset: usize, size: usize) {
+                use self::TransactionParameters::{Offset,Size};
+                // The offset is relative to the beginning of the flash module. There
+                // are 128 pages per flash module.
+                // TODO(jrvanwhy): Assumes the read is from the second flash bank.
+                if offset > H1B_FLASH_SIZE {
+                   return; // TODO(pal): Fails silently!
+                }
 
-	fn set_write_data(&self, data: &[u32]) {
-		for (i, &v) in data.iter().enumerate() { self.write_data[i].set(v); }
-	}
+                let offset = offset - 128 * super::WORDS_PER_PAGE;
+                self.transaction_parameters.write(Offset.val(offset as u32) + Size.val(size as u32));
+        }
 
-	fn trigger(&self, opcode: u32) {
-		self.program_erase_enable.set(0xb11924e1);
-		// TODO(jrvanwhy): Assumes the write is to the second flash bank (where
-		// the nvmem counter is).
-		self.pe_control_1.set(opcode);
-	}
+        fn set_write_data(&self, data: &[u32]) {
+                for (i, &v) in data.iter().enumerate() { self.write_data[i].set(v); }
+        }
+
+        fn trigger(&self, opcode: u32) {
+                self.program_erase_enable.set(0xb11924e1);
+                // TODO(jrvanwhy): Assumes the write is to the second flash bank (where
+                // the nvmem counter is).
+                self.pe_control_1.set(opcode);
+        }
 }

--- a/h1b/src/hil/flash/hardware.rs
+++ b/h1b/src/hil/flash/hardware.rs
@@ -12,28 +12,30 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use kernel::ReturnCode;
+
 /// The interface between the flash driver and the (real or fake) flash module.
 
 pub trait Hardware {
-	/// Returns true if an operation is running, false otherwise.
-	fn is_programming(&self) -> bool;
+        /// Returns true if an operation is running, false otherwise.
+        fn is_programming(&self) -> bool;
 
-	/// Read a single word from the flash (non-blocking). offset is in units of
-	/// words and is relative to the start of flash.
-	fn read(&self, offset: usize) -> u32;
+        /// Read a single word from the flash (non-blocking). offset is in units of
+        /// words and is relative to the start of flash.
+        fn read(&self, offset: usize) -> ReturnCode;
 
-	/// Reads the flash error code.
-	fn read_error(&self) -> u16;
+        /// Reads the flash error code.
+        fn read_error(&self) -> u16;
 
-	/// Set flash transaction parameters (word offset and size). The word offset
-	/// is relative to the start of flash and the size is one less than the
-	/// number of words to copy.
-	fn set_transaction(&self, offset: usize, size: usize);
+        /// Set flash transaction parameters (word offset and size). The word offset
+        /// is relative to the start of flash and the size is one less than the
+        /// number of words to copy.
+        fn set_transaction(&self, offset: usize, size: usize);
 
-	/// Fill the flash controller's write buffer. data must have a length no
-	/// larger than 32.
-	fn set_write_data(&self, data: &[u32]);
+        /// Fill the flash controller's write buffer. data must have a length no
+        /// larger than 32.
+        fn set_write_data(&self, data: &[u32]);
 
-	/// Kick off a smart program execution.
-	fn trigger(&self, opcode: u32);
+        /// Kick off a smart program execution.
+        fn trigger(&self, opcode: u32);
 }


### PR DESCRIPTION
This checks that the offset parameter passed to flash operations is within the bounds of the flash. Otherwise, a capsule can invoke a flash operation, pass a large offset, and read arbitrary RAM (allowing it to circumvent memory safety).

```
----------------------
`make prtest` summary:
----------------------
git rev-parse HEAD
4f5aa012305f90f9121a1e85cc7fddbdcf15a689
git status
On branch flash_bounds_fix
Your branch is up to date with 'origin/flash_bounds_fix'.

nothing to commit, working tree clean
```
