### PR TITLE
Tock version forward 60fb458

### DIFF
--- a/golf2/src/main.rs
+++ b/golf2/src/main.rs
@@ -70,7 +70,7 @@ static mut PROCESSES: [Option<&'static kernel::procs::ProcessType>; NUM_PROCS] =
 pub static mut STACK_MEMORY: [u8; 0x2000] = [0; 0x2000];
 
 pub struct Golf {
-    console: &'static capsules::console::Console<'static, UartDevice<'static>>,
+    console: &'static capsules::console::Console<'static>,
     gpio: &'static capsules::gpio::GPIO<'static, h1b::gpio::GPIOPin>,
     timer: &'static AlarmDriver<'static, VirtualMuxAlarm<'static, Timels<'static>>>,
     ipc: kernel::ipc::IPC,
@@ -174,24 +174,22 @@ pub unsafe fn reset_handler() {
             115200
         )
     );
-    hil::uart::UART::set_client(&h1b::uart::UART0, uart_mux);
+    hil::uart::Transmit::set_transmit_client(&h1b::uart::UART0, uart_mux);
 
     // Create virtual device for console.
     let console_uart = static_init!(UartDevice, UartDevice::new(uart_mux, true));
     console_uart.setup();
 
     let console = static_init!(
-        console::Console<UartDevice>,
+        console::Console<'static>,
         console::Console::new(
             console_uart,
-            115200,
             &mut console::WRITE_BUF,
             &mut console::READ_BUF,
             kernel.create_grant(&grant_cap)
         )
     );
-    hil::uart::UART::set_client(console_uart, console);
-    console.initialize();
+    hil::uart::Transmit::set_transmit_client(console_uart, console);
 
     // Create virtual device for kernel debug.
     let debugger_uart = static_init!(UartDevice, UartDevice::new(uart_mux, false));
@@ -204,7 +202,7 @@ pub unsafe fn reset_handler() {
             &mut kernel::debug::INTERNAL_BUF,
         )
     );
-    hil::uart::UART::set_client(debugger_uart, debugger);
+    hil::uart::Transmit::set_transmit_client(debugger_uart, debugger);
 
     let debug_wrapper = static_init!(
         kernel::debug::DebugWriterWrapper,


### PR DESCRIPTION
Updates Tock version to after new UART HIL was introduced, commit 60fb458.

```
----------------------
`make prtest` summary:
----------------------
git rev-parse HEAD
c5364ab6e6c584124cbb1100d1a1bba74d746eea
git status
On branch tock-version-forward-60fb458
Your branch is up to date with 'origin/tock-version-forward-60fb458'.

nothing to commit, working tree clean
```

