### PR TITLE
Reenable flash unit tests

### DIFF
--- a/golf2/src/main.rs
+++ b/golf2/src/main.rs
@@ -73,7 +73,7 @@ pub static mut STACK_MEMORY: [u8; 0x2000] = [0; 0x2000];
 
 pub struct Golf {
     console: &'static capsules::console::Console<'static>,
-    gpio: &'static capsules::gpio::GPIO<'static, h1b::gpio::GPIOPin>,
+    gpio: &'static capsules::gpio::GPIO<'static>,
     timer: &'static AlarmDriver<'static, VirtualMuxAlarm<'static, Timels<'static>>>,
     ipc: kernel::ipc::IPC,
     digest: &'static digest::DigestDriver<'static, h1b::crypto::sha::ShaEngine>,
@@ -214,11 +214,11 @@ pub unsafe fn reset_handler() {
 
     //debug!("Booting.");
     let gpio_pins = static_init!(
-        [&'static h1b::gpio::GPIOPin; 2],
+        [&'static kernel::hil::gpio::InterruptValuePin; 2],
         [&h1b::gpio::PORT0.pins[0], &h1b::gpio::PORT0.pins[1]]);
 
     let gpio = static_init!(
-        capsules::gpio::GPIO<'static, h1b::gpio::GPIOPin>,
+        capsules::gpio::GPIO<'static>,
         capsules::gpio::GPIO::new(gpio_pins, kernel.create_grant(&grant_cap)));
     for pin in gpio_pins.iter() {
         pin.set_client(gpio)

--- a/h1b/src/chip.rs
+++ b/h1b/src/chip.rs
@@ -56,7 +56,7 @@ impl Chip for Hotel {
                     5 => crypto::dcrypto::DCRYPTO.handle_receive_interrupt(),
 
                     //54 => (), // KEYMGR HKEY ALERT, ignored
-                    104...109 => crypto::aes::KEYMGR0_AES.handle_interrupt(nvic_num),
+                    104..=109 => crypto::aes::KEYMGR0_AES.handle_interrupt(nvic_num),
 
                     110 => crypto::sha::KEYMGR0_SHA.handle_interrupt(nvic_num),
                     111 => (), // KEYMGR0_SHA_WFIFO_FULL
@@ -77,13 +77,13 @@ impl Chip for Hotel {
                         usb::USB0.handle_interrupt()
                     },
 
-                    pin @ 65...80 => {
+                    pin @ 65..=80 => {
                         gpio::PORT0.pins[(pin - 65) as usize].handle_interrupt();
                     }
                     81 => {
                         // GPIO Combined interrupt... why does this remain asserted?
                     }
-                    pin @ 82...97 => {
+                    pin @ 82..=97 => {
                         gpio::PORT1.pins[(pin - 82) as usize].handle_interrupt();
                     }
                     98 => {

--- a/h1b/src/crypto/aes.rs
+++ b/h1b/src/crypto/aes.rs
@@ -100,7 +100,7 @@ impl From<u32> for ParsedInterrupt {
 
 pub struct AesEngine<'a>{
     regs: *mut Registers,
-    client: OptionalCell<&'a Client<'a>>,
+    client: OptionalCell<&'a dyn Client<'a>>,
     output: TakeCell<'a, [u8]>, // If output is None, put result into input buffer
     input: TakeCell<'a, [u8]>,
     read_index: Cell<usize>,
@@ -115,7 +115,7 @@ impl<'a> AES128<'a> for AesEngine<'a> {
 
     fn disable(&self) {}
 
-    fn set_client(&'a self, client: &'a Client<'a>) {
+    fn set_client(&'a self, client: &'a dyn Client<'a>) {
         self.set_client(client);
     }
 
@@ -259,7 +259,7 @@ impl<'a> AesEngine<'a> {
         })
     }
 
-    pub fn set_client(&self, client: &'a Client<'a>) {
+    pub fn set_client(&self, client: &'a dyn Client<'a>) {
         self.client.set(client);
     }
 

--- a/h1b/src/crypto/dcrypto.rs
+++ b/h1b/src/crypto/dcrypto.rs
@@ -172,7 +172,7 @@ pub trait DcryptoClient<'a> {
 pub trait Dcrypto<'a> {
 
     /// Set the client to receive callbacks from the engine.
-    fn set_client(&self, client: &'a DcryptoClient<'a>);
+    fn set_client(&self, client: &'a dyn DcryptoClient<'a>);
 
     /// Read the Dcrypto dmem. length is the number of bytes: it must
     /// be <= data.len. Offset is the offset at which to
@@ -254,7 +254,7 @@ struct Registers {
 
 pub struct DcryptoEngine<'a> {
     registers: *mut Registers,
-    client: Cell<Option<&'a DcryptoClient<'a>>>,
+    client: Cell<Option<&'a dyn DcryptoClient<'a>>>,
     state: Cell<State>,
     drom: TakeCell<'static, [u32; DROM_SIZE]>,
     dmem: TakeCell<'static, [u32; DMEM_SIZE]>,
@@ -468,7 +468,7 @@ impl<'a> DcryptoEngine<'a> {
 }
 
 impl<'a> Dcrypto<'a> for DcryptoEngine<'a> {
-    fn set_client(&self, client: &'a DcryptoClient<'a>) {
+    fn set_client(&self, client: &'a dyn DcryptoClient<'a>) {
         self.client.set(Some(client));
     }
 

--- a/h1b/src/gpio.rs
+++ b/h1b/src/gpio.rs
@@ -104,7 +104,7 @@ pub struct GPIOPin {
     pin: Pin,
     client_data: Cell<u32>,
     change: Cell<bool>,
-    client: Cell<Option<&'static hil::gpio::ClientWithValue>>,
+    client: Cell<Option<&'static dyn hil::gpio::ClientWithValue>>,
 }
 
 impl GPIOPin {
@@ -314,7 +314,7 @@ impl hil::gpio::Output for GPIOPin {
 }
 
 impl hil::gpio::InterruptWithValue for GPIOPin {
-    fn set_client(&self, client: &'static hil::gpio::ClientWithValue) {
+    fn set_client(&self, client: &'static dyn hil::gpio::ClientWithValue) {
         self.client.set(Some(client));
     }
 

--- a/h1b/src/hil/flash/driver.rs
+++ b/h1b/src/hil/flash/driver.rs
@@ -26,7 +26,7 @@ use super::smart_program::SmartProgramState;
 /// globalsec flash regions -- that must be done independently.
 pub struct FlashImpl<'d, A: Alarm + 'd, H: Hardware + 'd> {
     alarm: &'d A,
-    client: Cell<Option<&'d super::flash::Client<'d>>>,
+    client: Cell<Option<&'d dyn super::flash::Client<'d>>>,
     write_data: TakeCell<'d, [u32]>,
     write_pos: Cell<usize>,
     write_len: Cell<usize>,
@@ -94,7 +94,7 @@ impl<'d, A: Alarm, H: Hardware> super::flash::Flash<'d> for FlashImpl<'d, A, H> 
         (ReturnCode::SUCCESS, None)
     }
 
-    fn set_client(&'d self, client: &'d super::flash::Client<'d>) {
+    fn set_client(&'d self, client: &'d dyn super::flash::Client<'d>) {
         self.client.set(Some(client));
     }
 }

--- a/h1b/src/hil/flash/driver.rs
+++ b/h1b/src/hil/flash/driver.rs
@@ -133,10 +133,7 @@ impl<'d, A: Alarm, H: Hardware> ::kernel::hil::time::Client for FlashImpl<'d, A,
                     } else {
                         client.erase_done(code);
                     }
-                } else {
-                    debug!("No client!!!");
                 }
-
             } else {
                 self.smart_program_state.set(Some(state));
             }

--- a/h1b/src/hil/flash/flash.rs
+++ b/h1b/src/hil/flash/flash.rs
@@ -36,5 +36,5 @@ pub trait Flash<'d> {
     fn write(&self, target: usize, data: &'d mut [u32]) -> (ReturnCode, Option<&'d mut [u32]>);
 
     /// Links this driver to its client.
-    fn set_client(&'d self, client: &'d Client<'d>);
+    fn set_client(&'d self, client: &'d dyn Client<'d>);
 }

--- a/h1b/src/hil/flash/flash.rs
+++ b/h1b/src/hil/flash/flash.rs
@@ -16,25 +16,25 @@ use ::kernel::ReturnCode;
 
 /// Flash client -- receives callbacks when flash operations complete.
 pub trait Client<'d> {
-        fn erase_done(&self, ReturnCode);
-        fn write_done(&self, data: &'d mut [u32], ReturnCode);
+    fn erase_done(&self, ReturnCode);
+    fn write_done(&self, data: &'d mut [u32], ReturnCode);
 }
 
 /// Flash driver API.
 pub trait Flash<'d> {
-        /// Erases the specified flash page, setting it to all ones.
-        fn erase(&self, page: usize) -> ReturnCode;
+    /// Erases the specified flash page, setting it to all ones.
+    fn erase(&self, page: usize) -> ReturnCode;
 
-        /// Reads the given word from flash. Successful read returns
-        /// ReturnCode::SuccessWithValue with the value read; if the
-        /// offset is out of bounds, returns ReturnCode::ESIZE.
-        fn read(&self, offset: usize) -> ReturnCode;
+    /// Reads the given word from flash. Successful read returns
+    /// ReturnCode::SuccessWithValue with the value read; if the
+    /// offset is out of bounds, returns ReturnCode::ESIZE.
+    fn read(&self, offset: usize) -> ReturnCode;
 
-        /// Writes a buffer (of up to 32 words) into the given location in flash.
-        /// The target location is specified as an offset from the beginning of
-        /// flash in units of words.
-        fn write(&self, target: usize, data: &'d mut [u32]) -> (ReturnCode, Option<&'d mut [u32]>);
+    /// Writes a buffer (of up to 32 words) into the given location in flash.
+    /// The target location is specified as an offset from the beginning of
+    /// flash in units of words.
+    fn write(&self, target: usize, data: &'d mut [u32]) -> (ReturnCode, Option<&'d mut [u32]>);
 
-        /// Links this driver to its client.
-        fn set_client(&'d self, client: &'d Client<'d>);
+    /// Links this driver to its client.
+    fn set_client(&'d self, client: &'d Client<'d>);
 }

--- a/h1b/src/hil/flash/hardware.rs
+++ b/h1b/src/hil/flash/hardware.rs
@@ -17,25 +17,25 @@ use kernel::ReturnCode;
 /// The interface between the flash driver and the (real or fake) flash module.
 
 pub trait Hardware {
-        /// Returns true if an operation is running, false otherwise.
-        fn is_programming(&self) -> bool;
+    /// Returns true if an operation is running, false otherwise.
+    fn is_programming(&self) -> bool;
 
-        /// Read a single word from the flash (non-blocking). offset is in units of
-        /// words and is relative to the start of flash.
-        fn read(&self, offset: usize) -> ReturnCode;
+    /// Read a single word from the flash (non-blocking). offset is in units of
+    /// words and is relative to the start of flash.
+    fn read(&self, offset: usize) -> ReturnCode;
 
-        /// Reads the flash error code.
-        fn read_error(&self) -> u16;
+    /// Reads the flash error code.
+    fn read_error(&self) -> u16;
 
-        /// Set flash transaction parameters (word offset and size). The word offset
-        /// is relative to the start of flash and the size is one less than the
-        /// number of words to copy.
-        fn set_transaction(&self, offset: usize, size: usize);
+    /// Set flash transaction parameters (word offset and size). The word offset
+    /// is relative to the start of flash and the size is one less than the
+    /// number of words to copy.
+    fn set_transaction(&self, offset: usize, size: usize);
 
-        /// Fill the flash controller's write buffer. data must have a length no
-        /// larger than 32.
-        fn set_write_data(&self, data: &[u32]);
+    /// Fill the flash controller's write buffer. data must have a length no
+    /// larger than 32.
+    fn set_write_data(&self, data: &[u32]);
 
-        /// Kick off a smart program execution.
-        fn trigger(&self, opcode: u32);
+    /// Kick off a smart program execution.
+    fn trigger(&self, opcode: u32);
 }

--- a/h1b/src/hil/personality.rs
+++ b/h1b/src/hil/personality.rs
@@ -37,7 +37,7 @@ pub struct PersonalityData {
 /// [Client](trait.Client.html) trait.
 pub trait Personality<'a> {
     /// Set the client for callbacks on set calls.
-    fn set_client(&self, client: &'a Client<'a>);
+    fn set_client(&self, client: &'a dyn Client<'a>);
 
     /// Fetch the device's attestation data into a typed PersonalityData
     /// structure.

--- a/h1b/src/hil/rng.rs
+++ b/h1b/src/hil/rng.rs
@@ -87,7 +87,7 @@ pub enum Continue {
 pub trait RNG<'a> {
     /// Set the client for this random number generator.
     /// THe client will be called in response to requests for randomness.
-    fn set_client(&self, client: &'a Client);
+    fn set_client(&self, client: &'a dyn Client);
 
     /// Initiate acquiring a random number.
     ///
@@ -111,5 +111,5 @@ pub trait Client {
     /// The client returns either `Continue::More` if the iterator did not have
     /// enough random values and the client would like to be called again when
     /// more is available, or `Continue::Done`.
-    fn randomness_available(&self, randomness: &mut Iterator<Item = u32>) -> Continue;
+    fn randomness_available(&self, randomness: &mut dyn Iterator<Item = u32>) -> Continue;
 }

--- a/h1b/src/personality.rs
+++ b/h1b/src/personality.rs
@@ -35,8 +35,8 @@ enum State {
 
 pub struct PersonalityDriver<'a> {
     state: Cell<State>,
-    client: OptionalCell<&'a Client<'a>>,
-    flash: OptionalCell<&'a flash::Flash<'a>>,
+    client: OptionalCell<&'a dyn Client<'a>>,
+    flash: OptionalCell<&'a dyn flash::Flash<'a>>,
     write_buffer: TakeCell<'a, [u32]>,
 }
 
@@ -62,7 +62,7 @@ impl<'a> PersonalityDriver<'a> {
         }
     }
 
-    pub fn set_flash(&self, flash: &'a flash::Flash<'a>) {
+    pub fn set_flash(&self, flash: &'a dyn flash::Flash<'a>) {
         self.flash.set(flash);
     }
 
@@ -70,7 +70,7 @@ impl<'a> PersonalityDriver<'a> {
         self.write_buffer.replace(buf);
     }
 
-    pub fn set_client(&self, client: &'a Client<'a>) {
+    pub fn set_client(&self, client: &'a dyn Client<'a>) {
         self.client.replace(client);
     }
 
@@ -95,8 +95,7 @@ impl<'a> PersonalityDriver<'a> {
 }
 
 impl<'a> Personality<'a> for PersonalityDriver<'a> {
-
-    fn set_client(&self, client: &'a Client<'a>) {
+    fn set_client(&self, client: &'a dyn Client<'a>) {
         self.client.set(client);
     }
 

--- a/h1b/src/pinmux.rs
+++ b/h1b/src/pinmux.rs
@@ -23,6 +23,7 @@ pub struct Peripheral {
     pub select: VolatileCell<SelectablePin>,
 }
 
+#[repr(C)]
 pub struct Registers {
     pub diom0: Pin,
     pub diom1: Pin,
@@ -166,6 +167,7 @@ pub const PINMUX: *mut Registers = 0x40060000 as *mut Registers;
 
 #[repr(u32)]
 pub enum SelectablePin {
+    Disconnected = 0,
     Vio1 = 1,
     Vio0 = 2,
     Diob7 = 3,

--- a/h1b/src/test_rng.rs
+++ b/h1b/src/test_rng.rs
@@ -17,11 +17,11 @@
 use hil::rng::{Client, Continue, RNG};
 
 pub struct TestRng<'a> {
-    rng: &'a RNG<'a>,
+    rng: &'a dyn RNG<'a>,
 }
 
 impl<'a> TestRng<'a> {
-    pub fn new(rng: &'a RNG<'a>) -> Self {
+    pub fn new(rng: &'a dyn RNG<'a>) -> Self {
         TestRng { rng: rng }
     }
 
@@ -31,7 +31,7 @@ impl<'a> TestRng<'a> {
 }
 
 impl<'a> Client for TestRng<'a> {
-    fn randomness_available(&self, randomness: &mut Iterator<Item = u32>) -> Continue {
+    fn randomness_available(&self, randomness: &mut dyn Iterator<Item = u32>) -> Continue {
         print!("Randomness: \r");
         randomness.take(5).for_each(|r| print!("  [{:x}]\r", r));
         Continue::Done

--- a/h1b/src/timels.rs
+++ b/h1b/src/timels.rs
@@ -38,7 +38,7 @@ struct Registers {
 
 pub struct Timels<'a> {
     registers: *const Registers,
-    client: Cell<Option<&'a time::Client>>,
+    client: Cell<Option<&'a dyn time::Client>>,
     now: Cell<u32>,
 }
 
@@ -51,7 +51,7 @@ impl<'a> Timels<'a> {
         }
     }
 
-    pub fn set_client(&'static self, client: &'static time::Client) {
+    pub fn set_client(&'static self, client: &'static dyn time::Client) {
         self.client.set(Some(client));
     }
 

--- a/h1b/src/trng.rs
+++ b/h1b/src/trng.rs
@@ -137,7 +137,7 @@ pub static mut TRNG0: Trng<'static> = unsafe { Trng::new(TRNG0_BASE) };
 
 pub struct Trng<'a> {
     regs: *mut Registers,
-    client: Cell<Option<&'a Client32>>,
+    client: Cell<Option<&'a dyn Client32>>,
 }
 
 impl<'a> Trng<'a> {
@@ -180,7 +180,7 @@ impl<'a> Trng<'a> {
 
 impl<'a> Entropy32<'a> for Trng<'a> {
 
-    fn set_client(&self, client: &'a Client32) {
+    fn set_client(&self, client: &'a dyn Client32) {
         self.client.set(Some(client));
     }
 

--- a/h1b/src/uart.rs
+++ b/h1b/src/uart.rs
@@ -86,8 +86,8 @@ pub struct UART<'a> {
     tx_buffer: TakeCell<'static, [u8]>,
     tx_limit: Cell<usize>,
     tx_cursor: Cell<usize>,
-    tx_client: OptionalCell<&'a hil::uart::TransmitClient>,
-    rx_client: OptionalCell<&'a hil::uart::ReceiveClient>,
+    tx_client: OptionalCell<&'a dyn hil::uart::TransmitClient>,
+    rx_client: OptionalCell<&'a dyn hil::uart::ReceiveClient>,
 }
 
 impl<'a> hil::uart::Uart<'a> for UART<'a> {}
@@ -301,7 +301,7 @@ impl<'a> UART<'a> {
 }
 
 impl<'a> hil::uart::Transmit<'a> for UART<'a> {
-    fn set_transmit_client(&self, client: &'a hil::uart::TransmitClient) {
+    fn set_transmit_client(&self, client: &'a dyn hil::uart::TransmitClient) {
         self.tx_client.replace(client);
     }
 
@@ -330,7 +330,7 @@ impl<'a> hil::uart::Transmit<'a> for UART<'a> {
 }
 
 impl<'a> hil::uart::Receive<'a> for UART<'a> {
-    fn set_receive_client(&self, client: &'a hil::uart::ReceiveClient) {
+    fn set_receive_client(&self, client: &'a dyn hil::uart::ReceiveClient) {
         self.rx_client.replace(client);
     }
 

--- a/h1b/src/usb/driver.rs
+++ b/h1b/src/usb/driver.rs
@@ -43,13 +43,13 @@ pub struct App {
 }
 
 pub struct U2fSyscallDriver<'a> {
-    u2f_endpoints: &'a UsbHidU2f<'a>,
+    u2f_endpoints: &'a dyn UsbHidU2f<'a>,
     apps: Grant<App>,
     busy: Cell<bool>,
 }
 
 impl<'a> U2fSyscallDriver<'a> {
-    pub fn new(u2f: &'a UsbHidU2f<'a>, grant: Grant<App>) -> U2fSyscallDriver<'a> {
+    pub fn new(u2f: &'a dyn UsbHidU2f<'a>, grant: Grant<App>) -> U2fSyscallDriver<'a> {
         U2fSyscallDriver {
             u2f_endpoints: u2f,
             apps: grant,

--- a/h1b/src/usb/mod.rs
+++ b/h1b/src/usb/mod.rs
@@ -186,7 +186,7 @@ pub struct USB<'a> {
     strings: TakeCell<'static, [StringDescriptor]>,
 
     // Client to give callbacks to.
-    u2f_client: OptionalCell<&'a UsbHidU2fClient<'a>>,
+    u2f_client: OptionalCell<&'a dyn UsbHidU2fClient<'a>>,
 }
 
 // Hardware base address of the singleton USB controller
@@ -1352,7 +1352,7 @@ impl<'a> USB<'a> {
 /// Implementation of the HID U2F API for the USB device. It assumes
 /// that U2F is over endpoint 1.
 impl<'a> UsbHidU2f<'a> for USB<'a> {
-    fn set_u2f_client(&self, client: &'a UsbHidU2fClient<'a>) {
+    fn set_u2f_client(&self, client: &'a dyn UsbHidU2fClient<'a>) {
         self.u2f_client.set(client);
     }
 

--- a/h1b/src/usb/u2f.rs
+++ b/h1b/src/usb/u2f.rs
@@ -21,7 +21,7 @@ use usb::constants::EP_BUFFER_SIZE_WORDS;
 /// Trait a USB peripheral stack must implement to support the U2F syscall
 /// capsule.
 pub trait UsbHidU2f<'a> {
-    fn set_u2f_client(&self, client: &'a UsbHidU2fClient<'a>);
+    fn set_u2f_client(&self, client: &'a dyn UsbHidU2fClient<'a>);
 
     /// Reset the device and endpoints
     fn setup_u2f_descriptors(&self);

--- a/userspace/.cargo/config
+++ b/userspace/.cargo/config
@@ -20,4 +20,4 @@ target-dir = "../build/userspace/cargo"
 linker = "rust-lld"
 rustflags = ["-C", "link-arg=-T./layout.ld",
              "-C", "relocation-model=static",
-             "-Z", "linker-flavor=ld.lld"]
+             "-C", "linker-flavor=ld.lld"]

--- a/userspace/Build.mk
+++ b/userspace/Build.mk
@@ -21,7 +21,7 @@ userspace/build: $(addsuffix /build,$(BUILD_SUBDIRS))
 
 .PHONY: userspace/check
 userspace/check:
-	cd userspace && cargo check --release
+	cd userspace && TOCK_KERNEL_VERSION=h1b_tests cargo check --release
 
 .PHONY: userspace/clean
 userspace/clean:

--- a/userspace/h1b_tests/Build.mk
+++ b/userspace/h1b_tests/Build.mk
@@ -18,7 +18,7 @@ userspace/h1b_tests/build: build/userspace/h1b_tests/full_image
 .PHONY: userspace/h1b_tests/check
 userspace/h1b_tests/check:
 	cd userspace/h1b_tests && TOCK_KERNEL_VERSION=h1b_tests cargo check \
-		--release -Z offline
+		--offline --release
 
 .PHONY: userspace/h1b_tests/devicetests
 userspace/h1b_tests/devicetests: build/cargo-host/release/runner \
@@ -33,7 +33,7 @@ userspace/h1b_tests/devicetests: build/cargo-host/release/runner \
 .PHONY: userspace/h1b_tests/doc
 userspace/h1b_tests/doc:
 	cd userspace/h1b_tests && TOCK_KERNEL_VERSION=h1b_tests cargo doc \
-		--release -Z offline
+		--offline --release
 
 .PHONY: userspace/h1b_tests/localtests
 userspace/h1b_tests/localtests:
@@ -57,7 +57,7 @@ userspace/h1b_tests/run: build/cargo-host/release/runner \
 build/userspace/h1b_tests/h1b_tests:
 	rm -f build/userspace/cargo/thumbv7m-none-eabi/release/h1b_tests-*
 	cd userspace/h1b_tests && TOCK_KERNEL_VERSION=h1b_tests \
-		cargo test --no-run --release -Z offline
+		cargo test --no-run --offline --release
 	mkdir -p build/userspace/h1b_tests/
 	find build/userspace/cargo/thumbv7m-none-eabi/release/ -maxdepth 1 -regex \
 		'build/userspace/cargo/thumbv7m-none-eabi/release/h1b_tests-[^.]+' \

--- a/userspace/h1b_tests/src/hil/flash/driver.rs
+++ b/userspace/h1b_tests/src/hil/flash/driver.rs
@@ -28,8 +28,8 @@ static mut WRITE_BUF: [u32; 1] = [0; 1];
 #[cfg(test)]
 #[derive(Clone,Copy,PartialEq)]
 enum MockClientState {
-        EraseDone(kernel::ReturnCode),
-        WriteDone(kernel::ReturnCode),
+    EraseDone(kernel::ReturnCode),
+    WriteDone(kernel::ReturnCode),
 }
 
 #[cfg(test)]
@@ -39,251 +39,251 @@ struct MockClient {
 
 #[cfg(test)]
 impl<'a> MockClient {
-        pub fn new() -> Self {
-                MockClient { state: core::cell::Cell::new(None) }
-        }
+    pub fn new() -> Self {
+        MockClient { state: core::cell::Cell::new(None) }
+    }
 
-        pub fn state(&self) -> Option<MockClientState> { self.state.get() }
+    pub fn state(&self) -> Option<MockClientState> { self.state.get() }
 }
 
 #[cfg(test)]
 impl<'a> h1b::hil::flash::Client<'a> for MockClient {
-        fn erase_done(&self, code: kernel::ReturnCode) {
-                self.state.set(Some(MockClientState::EraseDone(code)));
-        }
+    fn erase_done(&self, code: kernel::ReturnCode) {
+        self.state.set(Some(MockClientState::EraseDone(code)));
+    }
 
-        fn write_done(&self, _data: &'a mut [u32], code: kernel::ReturnCode) {
-                self.state.set(Some(MockClientState::WriteDone(code)));
-        }
+    fn write_done(&self, _data: &'a mut [u32], code: kernel::ReturnCode) {
+        self.state.set(Some(MockClientState::WriteDone(code)));
+    }
 }
 
 #[test]
 fn erase() -> bool {
-        use kernel::hil::time::Client;
-        let alarm = crate::hil::flash::mock_alarm::MockAlarm::new();
-        let client = MockClient::new();
-        let hw = h1b::hil::flash::fake::FakeHw::new();
+    use kernel::hil::time::Client;
+    let alarm = crate::hil::flash::mock_alarm::MockAlarm::new();
+    let client = MockClient::new();
+    let hw = h1b::hil::flash::fake::FakeHw::new();
 
-        // First attempt.
-        let driver = unsafe { h1b::hil::flash::FlashImpl::new(&alarm, &hw) };
-        driver.set_client(&client);
-        require!(driver.erase(2) == kernel::ReturnCode::SUCCESS);
-        require!(alarm.get_alarm() == alarm.now() + ERASE_TIME);
-        require!(client.state() == None);
-        require!(hw.is_programming() == true);
+    // First attempt.
+    let driver = unsafe { h1b::hil::flash::FlashImpl::new(&alarm, &hw) };
+    driver.set_client(&client);
+    require!(driver.erase(2) == kernel::ReturnCode::SUCCESS);
+    require!(alarm.get_alarm() == alarm.now() + ERASE_TIME);
+    require!(client.state() == None);
+    require!(hw.is_programming() == true);
 
-        // Indicate an error, let the driver retry.
-        alarm.set_time(ERASE_TIME);
-        hw.inject_result(0b100);
-        driver.fired();
-        require!(alarm.get_alarm() == 2 * ERASE_TIME);
-        require!(hw.is_programming() == true);
-        require!(client.state() == None);
+    // Indicate an error, let the driver retry.
+    alarm.set_time(ERASE_TIME);
+    hw.inject_result(0b100);
+    driver.fired();
+    require!(alarm.get_alarm() == 2 * ERASE_TIME);
+    require!(hw.is_programming() == true);
+    require!(client.state() == None);
 
-        // Let the operation finish successfully.
-        alarm.set_time(2 * ERASE_TIME);
-        hw.finish_operation();
-        driver.fired();
-        require!(alarm.get_alarm() == 0);
-        require!(hw.is_programming() == false);
-        require!(hw.read(1300) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
-        require!(client.state() == Some(MockClientState::EraseDone(kernel::ReturnCode::SUCCESS)));
-        require!(driver.read(1300) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
+    // Let the operation finish successfully.
+    alarm.set_time(2 * ERASE_TIME);
+    hw.finish_operation();
+    driver.fired();
+    require!(alarm.get_alarm() == 0);
+    require!(hw.is_programming() == false);
+    require!(hw.read(1300) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
+    require!(client.state() == Some(MockClientState::EraseDone(kernel::ReturnCode::SUCCESS)));
+    require!(driver.read(1300) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
 
-        true
+    true
 }
 
 #[test]
 fn erase_max_retries() -> bool {
-        use kernel::hil::time::Client;
-        let alarm = crate::hil::flash::mock_alarm::MockAlarm::new();
-        let client = MockClient::new();
-        let hw = h1b::hil::flash::fake::FakeHw::new();
-        let driver = unsafe { h1b::hil::flash::FlashImpl::new(&alarm, &hw) };
-        driver.set_client(&client);
-        require!(driver.erase(2) == kernel::ReturnCode::SUCCESS);
-        require!(alarm.get_alarm() == alarm.now() + ERASE_TIME);
-        require!(client.state() == None);
-        require!(hw.is_programming() == true);
+    use kernel::hil::time::Client;
+    let alarm = crate::hil::flash::mock_alarm::MockAlarm::new();
+    let client = MockClient::new();
+    let hw = h1b::hil::flash::fake::FakeHw::new();
+    let driver = unsafe { h1b::hil::flash::FlashImpl::new(&alarm, &hw) };
+    driver.set_client(&client);
+    require!(driver.erase(2) == kernel::ReturnCode::SUCCESS);
+    require!(alarm.get_alarm() == alarm.now() + ERASE_TIME);
+    require!(client.state() == None);
+    require!(hw.is_programming() == true);
 
-        for i in 1..45 {
-                // Indicate an error, let the driver retry.
-                alarm.set_time(ERASE_TIME * i);
-                hw.inject_result(0b100);
-                driver.fired();
-                require!(alarm.get_alarm() == alarm.now() + ERASE_TIME);
-                require!(hw.is_programming() == true);
-                require!(client.state() == None);
-        }
-
-        // Last try.
+    for i in 1..45 {
+        // Indicate an error, let the driver retry.
+        alarm.set_time(ERASE_TIME * i);
         hw.inject_result(0b100);
         driver.fired();
-        require!(alarm.get_alarm() == 0);
-        require!(hw.is_programming() == false);
-        require!(client.state() == Some(MockClientState::EraseDone(kernel::ReturnCode::FAIL)));
-        require!(hw.read(1300) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
-        require!(driver.read(1300) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
+        require!(alarm.get_alarm() == alarm.now() + ERASE_TIME);
+        require!(hw.is_programming() == true);
+        require!(client.state() == None);
+    }
 
-        true
+    // Last try.
+    hw.inject_result(0b100);
+    driver.fired();
+    require!(alarm.get_alarm() == 0);
+    require!(hw.is_programming() == false);
+    require!(client.state() == Some(MockClientState::EraseDone(kernel::ReturnCode::FAIL)));
+    require!(hw.read(1300) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
+    require!(driver.read(1300) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
+
+    true
 }
 
 #[test]
 fn write_then_erase() -> bool {
-        use kernel::hil::time::Client;
-        let alarm = crate::hil::flash::mock_alarm::MockAlarm::new();
-        let client = MockClient::new();
-        let hw = h1b::hil::flash::fake::FakeHw::new();
+    use kernel::hil::time::Client;
+    let alarm = crate::hil::flash::mock_alarm::MockAlarm::new();
+    let client = MockClient::new();
+    let hw = h1b::hil::flash::fake::FakeHw::new();
 
-        // Write
-        let driver = unsafe { h1b::hil::flash::FlashImpl::new(&alarm, &hw) };
-        driver.set_client(&client);
+    // Write
+    let driver = unsafe { h1b::hil::flash::FlashImpl::new(&alarm, &hw) };
+    driver.set_client(&client);
 
-        unsafe {
-            WRITE_BUF[0] = 0xFFFFABCD;
-            require!(driver.write(1300, &mut WRITE_BUF) == (kernel::ReturnCode::SUCCESS, None));
-        }
-        require!(alarm.get_alarm() == alarm.now() + WRITE_WORD_TIME);
-        require!(client.state() == None);
-        require!(hw.is_programming() == true);
-        alarm.set_time(WRITE_WORD_TIME);
-        hw.inject_result(0);
-        driver.fired();
-        require!(hw.is_programming() == true);
-        require!(client.state() == None);
-        hw.finish_operation();
-        driver.fired();
-        require!(alarm.get_alarm() == 0);
-        require!(hw.is_programming() == false);
-        require!(hw.read(1300) == ReturnCode::SuccessWithValue { value: 0xFFFFABCD });
-        require!(client.state() == Some(MockClientState::WriteDone(kernel::ReturnCode::SUCCESS)));
-        require!(driver.read(1300) == ReturnCode::SuccessWithValue { value: 0xFFFFABCD });
+    unsafe {
+        WRITE_BUF[0] = 0xFFFFABCD;
+        require!(driver.write(1300, &mut WRITE_BUF) == (kernel::ReturnCode::SUCCESS, None));
+    }
+    require!(alarm.get_alarm() == alarm.now() + WRITE_WORD_TIME);
+    require!(client.state() == None);
+    require!(hw.is_programming() == true);
+    alarm.set_time(WRITE_WORD_TIME);
+    hw.inject_result(0);
+    driver.fired();
+    require!(hw.is_programming() == true);
+    require!(client.state() == None);
+    hw.finish_operation();
+    driver.fired();
+    require!(alarm.get_alarm() == 0);
+    require!(hw.is_programming() == false);
+    require!(hw.read(1300) == ReturnCode::SuccessWithValue { value: 0xFFFFABCD });
+    require!(client.state() == Some(MockClientState::WriteDone(kernel::ReturnCode::SUCCESS)));
+    require!(driver.read(1300) == ReturnCode::SuccessWithValue { value: 0xFFFFABCD });
 
-        // Erase
-        let driver = unsafe { h1b::hil::flash::FlashImpl::new(&alarm, &hw) };
-        driver.set_client(&client);
-        require!(driver.erase(2) == kernel::ReturnCode::SUCCESS);
-        require!(alarm.get_alarm() == alarm.now() + ERASE_TIME);
-        require!(hw.is_programming() == true);
-        alarm.set_time(WRITE_WORD_TIME + ERASE_TIME);
-        hw.finish_operation();
-        driver.fired();
-        require!(alarm.get_alarm() == 0);
-        require!(hw.is_programming() == false);
-        require!(hw.read(1300) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
-        require!(client.state() == Some(MockClientState::EraseDone(kernel::ReturnCode::SUCCESS)));
-        require!(driver.read(1300) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
+    // Erase
+    let driver = unsafe { h1b::hil::flash::FlashImpl::new(&alarm, &hw) };
+    driver.set_client(&client);
+    require!(driver.erase(2) == kernel::ReturnCode::SUCCESS);
+    require!(alarm.get_alarm() == alarm.now() + ERASE_TIME);
+    require!(hw.is_programming() == true);
+    alarm.set_time(WRITE_WORD_TIME + ERASE_TIME);
+    hw.finish_operation();
+    driver.fired();
+    require!(alarm.get_alarm() == 0);
+    require!(hw.is_programming() == false);
+    require!(hw.read(1300) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
+    require!(client.state() == Some(MockClientState::EraseDone(kernel::ReturnCode::SUCCESS)));
+    require!(driver.read(1300) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
 
-        true
+    true
 }
 
 #[test]
 fn successful_program() -> bool {
-        use kernel::hil::time::Client;
-        let alarm = crate::hil::flash::mock_alarm::MockAlarm::new();
-        let client = MockClient::new();
-        let hw = h1b::hil::flash::fake::FakeHw::new();
+    use kernel::hil::time::Client;
+    let alarm = crate::hil::flash::mock_alarm::MockAlarm::new();
+    let client = MockClient::new();
+    let hw = h1b::hil::flash::fake::FakeHw::new();
 
-        // First attempt.
-        let driver = unsafe { h1b::hil::flash::FlashImpl::new(&alarm, &hw) };
-        driver.set_client(&client);
+    // First attempt.
+    let driver = unsafe { h1b::hil::flash::FlashImpl::new(&alarm, &hw) };
+    driver.set_client(&client);
 
-        unsafe {
-            WRITE_BUF[0] = 0xFFFFABCD;
-            require!(driver.write(1300, &mut WRITE_BUF) == (kernel::ReturnCode::SUCCESS, None));
-        }
-        require!(alarm.get_alarm() == alarm.now() + WRITE_WORD_TIME);
-        require!(client.state() == None);
-        require!(hw.is_programming() == true);
+    unsafe {
+        WRITE_BUF[0] = 0xFFFFABCD;
+        require!(driver.write(1300, &mut WRITE_BUF) == (kernel::ReturnCode::SUCCESS, None));
+    }
+    require!(alarm.get_alarm() == alarm.now() + WRITE_WORD_TIME);
+    require!(client.state() == None);
+    require!(hw.is_programming() == true);
 
-        // Indicate an error, let the driver retry.
-        alarm.set_time(WRITE_WORD_TIME);
-        hw.inject_result(0b100);
-        driver.fired();
-        require!(alarm.get_alarm() == 2 * WRITE_WORD_TIME);
-        require!(hw.is_programming() == true);
-        require!(client.state() == None);
+    // Indicate an error, let the driver retry.
+    alarm.set_time(WRITE_WORD_TIME);
+    hw.inject_result(0b100);
+    driver.fired();
+    require!(alarm.get_alarm() == 2 * WRITE_WORD_TIME);
+    require!(hw.is_programming() == true);
+    require!(client.state() == None);
 
-        // Let the operation finish successfully (including the final pulse).
-        alarm.set_time(2 * WRITE_WORD_TIME);
-        hw.inject_result(0);
-        driver.fired();
-        require!(alarm.get_alarm() == 3 * WRITE_WORD_TIME);
-        require!(hw.is_programming() == true);
-        require!(client.state() == None);
-        hw.finish_operation();
-        driver.fired();
-        require!(alarm.get_alarm() == 0);
-        require!(hw.is_programming() == false);
-        require!(client.state() == Some(MockClientState::WriteDone(kernel::ReturnCode::SUCCESS)));
-        require!(driver.read(1300) == ReturnCode::SuccessWithValue { value: 0xFFFFABCD });
+    // Let the operation finish successfully (including the final pulse).
+    alarm.set_time(2 * WRITE_WORD_TIME);
+    hw.inject_result(0);
+    driver.fired();
+    require!(alarm.get_alarm() == 3 * WRITE_WORD_TIME);
+    require!(hw.is_programming() == true);
+    require!(client.state() == None);
+    hw.finish_operation();
+    driver.fired();
+    require!(alarm.get_alarm() == 0);
+    require!(hw.is_programming() == false);
+    require!(client.state() == Some(MockClientState::WriteDone(kernel::ReturnCode::SUCCESS)));
+    require!(driver.read(1300) == ReturnCode::SuccessWithValue { value: 0xFFFFABCD });
 
-        true
+    true
 }
 
 #[test]
 fn timeout() -> bool {
-        use kernel::hil::time::Client;
-        let alarm = crate::hil::flash::mock_alarm::MockAlarm::new();
-        let client = MockClient::new();
-        let hw = h1b::hil::flash::fake::FakeHw::new();
-        hw.set_transaction(1300, 1);
-        hw.set_write_data(&[0xFFFF0FFF]);
+    use kernel::hil::time::Client;
+    let alarm = crate::hil::flash::mock_alarm::MockAlarm::new();
+    let client = MockClient::new();
+    let hw = h1b::hil::flash::fake::FakeHw::new();
+    hw.set_transaction(1300, 1);
+    hw.set_write_data(&[0xFFFF0FFF]);
 
-        // First attempt.
-        let driver = unsafe { h1b::hil::flash::FlashImpl::new(&alarm, &hw) };
-        driver.set_client(&client);
+    // First attempt.
+    let driver = unsafe { h1b::hil::flash::FlashImpl::new(&alarm, &hw) };
+    driver.set_client(&client);
 
-        unsafe {
-            WRITE_BUF[0] = 0xFFFFABCD;
-            require!(driver.write(1300, &mut WRITE_BUF) == (kernel::ReturnCode::SUCCESS, None));
-        }
-        require!(alarm.get_alarm() == alarm.now() + WRITE_WORD_TIME);
-        require!(client.state() == None);
-        require!(hw.is_programming() == true);
+    unsafe {
+        WRITE_BUF[0] = 0xFFFFABCD;
+        require!(driver.write(1300, &mut WRITE_BUF) == (kernel::ReturnCode::SUCCESS, None));
+    }
+    require!(alarm.get_alarm() == alarm.now() + WRITE_WORD_TIME);
+    require!(client.state() == None);
+    require!(hw.is_programming() == true);
 
-        // Indicate a timeout.
-        alarm.set_time(WRITE_WORD_TIME);
-        driver.fired();
-        require!(alarm.get_alarm() == 0);
-        require!(client.state() == Some(MockClientState::WriteDone(kernel::ReturnCode::FAIL)));
+    // Indicate a timeout.
+    alarm.set_time(WRITE_WORD_TIME);
+    driver.fired();
+    require!(alarm.get_alarm() == 0);
+    require!(client.state() == Some(MockClientState::WriteDone(kernel::ReturnCode::FAIL)));
 
-        true
+    true
 }
 
 #[test]
 fn write_max_retries() -> bool {
-        use kernel::hil::time::Client;
-        let alarm = crate::hil::flash::mock_alarm::MockAlarm::new();
-        let client = MockClient::new();
-        let hw = h1b::hil::flash::fake::FakeHw::new();
-        let driver = unsafe { h1b::hil::flash::FlashImpl::new(&alarm, &hw) };
-        driver.set_client(&client);
+    use kernel::hil::time::Client;
+    let alarm = crate::hil::flash::mock_alarm::MockAlarm::new();
+    let client = MockClient::new();
+    let hw = h1b::hil::flash::fake::FakeHw::new();
+    let driver = unsafe { h1b::hil::flash::FlashImpl::new(&alarm, &hw) };
+    driver.set_client(&client);
 
-        unsafe {
-            WRITE_BUF[0] = 0xFFFFABCD;
-            require!(driver.write(1300, &mut WRITE_BUF) == (kernel::ReturnCode::SUCCESS, None));
-        }
-        require!(alarm.get_alarm() == alarm.now() + WRITE_WORD_TIME);
-        require!(client.state() == None);
-        require!(hw.is_programming() == true);
+    unsafe {
+        WRITE_BUF[0] = 0xFFFFABCD;
+        require!(driver.write(1300, &mut WRITE_BUF) == (kernel::ReturnCode::SUCCESS, None));
+    }
+    require!(alarm.get_alarm() == alarm.now() + WRITE_WORD_TIME);
+    require!(client.state() == None);
+    require!(hw.is_programming() == true);
 
-        for _ in 1..8 {
-                // Indicate an error, let the driver retry.
-                alarm.set_time(100 * WRITE_WORD_TIME);
-                hw.inject_result(0b100);
-                driver.fired();
-                require!(alarm.get_alarm() == alarm.now() + WRITE_WORD_TIME);
-                require!(hw.is_programming() == true);
-                require!(client.state() == None);
-        }
-
-        // Last try.
+    for _ in 1..8 {
+        // Indicate an error, let the driver retry.
+        alarm.set_time(100 * WRITE_WORD_TIME);
         hw.inject_result(0b100);
         driver.fired();
-        require!(alarm.get_alarm() == 0);
-        require!(hw.is_programming() == false);
-        require!(client.state() == Some(MockClientState::WriteDone(kernel::ReturnCode::FAIL)));
+        require!(alarm.get_alarm() == alarm.now() + WRITE_WORD_TIME);
+        require!(hw.is_programming() == true);
+        require!(client.state() == None);
+    }
 
-        true
+    // Last try.
+    hw.inject_result(0b100);
+    driver.fired();
+    require!(alarm.get_alarm() == 0);
+    require!(hw.is_programming() == false);
+    require!(client.state() == Some(MockClientState::WriteDone(kernel::ReturnCode::FAIL)));
+
+    true
 }

--- a/userspace/h1b_tests/src/hil/flash/fake.rs
+++ b/userspace/h1b_tests/src/hil/flash/fake.rs
@@ -18,152 +18,152 @@ use kernel::ReturnCode;
 /// functionality. Simulates both failed operations and successful operations.
 #[test]
 fn fake_hw() -> bool {
-	use { h1b::hil::flash::Hardware, test::require };
-	let fake = h1b::hil::flash::fake::FakeHw::new();
+    use { h1b::hil::flash::Hardware, test::require };
+    let fake = h1b::hil::flash::fake::FakeHw::new();
 
-	// Verify the initial state of the flash.
-	require!(fake.is_programming() == false);
-	require!(fake.read(512) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
-	require!(fake.read(1023) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
-	require!(fake.read(1300) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
-	require!(fake.read(1301) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
+    // Verify the initial state of the flash.
+    require!(fake.is_programming() == false);
+    require!(fake.read(512) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
+    require!(fake.read(1023) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
+    require!(fake.read(1300) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
+    require!(fake.read(1301) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
 
-	// Operation 1: successful write to two words.
-	fake.set_transaction(1300, 2 - 1);
-	fake.set_write_data(&[0xFFFF0FFF, 0xFFFAFFFF]);
-	fake.trigger(h1b::hil::flash::driver::WRITE_OPCODE);
-	require!(fake.is_programming() == true);
-	fake.inject_result(0);
-	require!(fake.is_programming() == false);
-	require!(fake.read_error() == 0);
-	fake.trigger(h1b::hil::flash::driver::WRITE_OPCODE);
-	require!(fake.is_programming() == true);
-	fake.finish_operation();
-	require!(fake.read_error() == 0);
-	require!(fake.is_programming() == false);
-	require!(fake.read(512) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
-	require!(fake.read(1023) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
-	require!(fake.read(1300) == ReturnCode::SuccessWithValue { value: 0xFFFF0FFF });
-	require!(fake.read(1301) == ReturnCode::SuccessWithValue { value: 0xFFFAFFFF });
+    // Operation 1: successful write to two words.
+    fake.set_transaction(1300, 2 - 1);
+    fake.set_write_data(&[0xFFFF0FFF, 0xFFFAFFFF]);
+    fake.trigger(h1b::hil::flash::driver::WRITE_OPCODE);
+    require!(fake.is_programming() == true);
+    fake.inject_result(0);
+    require!(fake.is_programming() == false);
+    require!(fake.read_error() == 0);
+    fake.trigger(h1b::hil::flash::driver::WRITE_OPCODE);
+    require!(fake.is_programming() == true);
+    fake.finish_operation();
+    require!(fake.read_error() == 0);
+    require!(fake.is_programming() == false);
+    require!(fake.read(512) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
+    require!(fake.read(1023) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
+    require!(fake.read(1300) == ReturnCode::SuccessWithValue { value: 0xFFFF0FFF });
+    require!(fake.read(1301) == ReturnCode::SuccessWithValue { value: 0xFFFAFFFF });
 
-	// Operation 2: failed write. Verifies the write doesn't change anything.
-	fake.set_transaction(1300, 2 - 1);
-	fake.set_write_data(&[0xFFFF00FF, 0xFFAAFFFF]);
-	fake.trigger(h1b::hil::flash::driver::WRITE_OPCODE);
-	require!(fake.is_programming() == true);
-	fake.inject_result(0x8);  // Program failed
-	require!(fake.read_error() == 0x8);
-	require!(fake.is_programming() == false);
-	require!(fake.read(512) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
-	require!(fake.read(1023) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
-	require!(fake.read(1300) == ReturnCode::SuccessWithValue { value: 0xFFFF0FFF });
-	require!(fake.read(1301) == ReturnCode::SuccessWithValue { value: 0xFFFAFFFF });
+    // Operation 2: failed write. Verifies the write doesn't change anything.
+    fake.set_transaction(1300, 2 - 1);
+    fake.set_write_data(&[0xFFFF00FF, 0xFFAAFFFF]);
+    fake.trigger(h1b::hil::flash::driver::WRITE_OPCODE);
+    require!(fake.is_programming() == true);
+    fake.inject_result(0x8);  // Program failed
+    require!(fake.read_error() == 0x8);
+    require!(fake.is_programming() == false);
+    require!(fake.read(512) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
+    require!(fake.read(1023) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
+    require!(fake.read(1300) == ReturnCode::SuccessWithValue { value: 0xFFFF0FFF });
+    require!(fake.read(1301) == ReturnCode::SuccessWithValue { value: 0xFFFAFFFF });
 
-	// Operation 3: successful write to one word. Verifies the write doesn't
-	// overlap to the next word.
-	fake.set_transaction(1300, 1 - 1);
-	fake.set_write_data(&[0xFFFF00FF]);
-	fake.trigger(h1b::hil::flash::driver::WRITE_OPCODE);
-	require!(fake.is_programming() == true);
-	fake.inject_result(0);
-	require!(fake.is_programming() == false);
-	require!(fake.read_error() == 0);
-	fake.trigger(h1b::hil::flash::driver::WRITE_OPCODE);
-	require!(fake.is_programming() == true);
-	fake.finish_operation();
-	require!(fake.read_error() == 0);
-	require!(fake.is_programming() == false);
-	require!(fake.read(512) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
-	require!(fake.read(1023) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
-	require!(fake.read(1300) == ReturnCode::SuccessWithValue { value: 0xFFFF00FF });
-	require!(fake.read(1301) == ReturnCode::SuccessWithValue { value: 0xFFFAFFFF });
+    // Operation 3: successful write to one word. Verifies the write doesn't
+    // overlap to the next word.
+    fake.set_transaction(1300, 1 - 1);
+    fake.set_write_data(&[0xFFFF00FF]);
+    fake.trigger(h1b::hil::flash::driver::WRITE_OPCODE);
+    require!(fake.is_programming() == true);
+    fake.inject_result(0);
+    require!(fake.is_programming() == false);
+    require!(fake.read_error() == 0);
+    fake.trigger(h1b::hil::flash::driver::WRITE_OPCODE);
+    require!(fake.is_programming() == true);
+    fake.finish_operation();
+    require!(fake.read_error() == 0);
+    require!(fake.is_programming() == false);
+    require!(fake.read(512) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
+    require!(fake.read(1023) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
+    require!(fake.read(1300) == ReturnCode::SuccessWithValue { value: 0xFFFF00FF });
+    require!(fake.read(1301) == ReturnCode::SuccessWithValue { value: 0xFFFAFFFF });
 
-	// Operation 4: successful erase of the second page. Confirms the erase
-	// does not affect the third page.
-	fake.set_transaction(512, 0);
-	require!(fake.is_programming() == false);
-	fake.trigger(h1b::hil::flash::driver::ERASE_OPCODE);
-	require!(fake.is_programming() == true);
-	fake.finish_operation();
-	require!(fake.read_error() == 0);
-	require!(fake.is_programming() == false);
-	require!(fake.read(512) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
-	require!(fake.read(1023) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
-	require!(fake.read(1300) == ReturnCode::SuccessWithValue { value: 0xFFFF00FF });
-	require!(fake.read(1301) == ReturnCode::SuccessWithValue { value: 0xFFFAFFFF });
+    // Operation 4: successful erase of the second page. Confirms the erase
+    // does not affect the third page.
+    fake.set_transaction(512, 0);
+    require!(fake.is_programming() == false);
+    fake.trigger(h1b::hil::flash::driver::ERASE_OPCODE);
+    require!(fake.is_programming() == true);
+    fake.finish_operation();
+    require!(fake.read_error() == 0);
+    require!(fake.is_programming() == false);
+    require!(fake.read(512) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
+    require!(fake.read(1023) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
+    require!(fake.read(1300) == ReturnCode::SuccessWithValue { value: 0xFFFF00FF });
+    require!(fake.read(1301) == ReturnCode::SuccessWithValue { value: 0xFFFAFFFF });
 
-	// Operation 5: successful erase of the third page. Verifies the erase
-	// affects the values in the third page.
-	fake.set_transaction(1024, 0);
-	require!(fake.is_programming() == false);
-	fake.trigger(h1b::hil::flash::driver::ERASE_OPCODE);
-	require!(fake.is_programming() == true);
-	fake.finish_operation();
-	require!(fake.read_error() == 0);
-	require!(fake.is_programming() == false);
-	require!(fake.read(512) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
-	require!(fake.read(1023) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
-	require!(fake.read(1300) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
-	require!(fake.read(1301) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
+    // Operation 5: successful erase of the third page. Verifies the erase
+    // affects the values in the third page.
+    fake.set_transaction(1024, 0);
+    require!(fake.is_programming() == false);
+    fake.trigger(h1b::hil::flash::driver::ERASE_OPCODE);
+    require!(fake.is_programming() == true);
+    fake.finish_operation();
+    require!(fake.read_error() == 0);
+    require!(fake.is_programming() == false);
+    require!(fake.read(512) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
+    require!(fake.read(1023) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
+    require!(fake.read(1300) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
+    require!(fake.read(1301) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
 
-	// At this point, the fake flash module's log is full. Attempting another
-	// operation should result in a flash error even if the operation is
-	// otherwise valid.
-	fake.set_transaction(1300, 1 - 1);
-	fake.set_write_data(&[0xABCDC0FF]);
-	fake.trigger(h1b::hil::flash::driver::WRITE_OPCODE);
-	require!(fake.is_programming() == true);
-	fake.finish_operation();
-	require!(fake.read_error() == 0x8);
-	require!(fake.is_programming() == false);
-	require!(fake.read(512) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
-	require!(fake.read(1023) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
-	require!(fake.read(1300) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
-	require!(fake.read(1301) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
+    // At this point, the fake flash module's log is full. Attempting another
+    // operation should result in a flash error even if the operation is
+    // otherwise valid.
+    fake.set_transaction(1300, 1 - 1);
+    fake.set_write_data(&[0xABCDC0FF]);
+    fake.trigger(h1b::hil::flash::driver::WRITE_OPCODE);
+    require!(fake.is_programming() == true);
+    fake.finish_operation();
+    require!(fake.read_error() == 0x8);
+    require!(fake.is_programming() == false);
+    require!(fake.read(512) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
+    require!(fake.read(1023) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
+    require!(fake.read(1300) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
+    require!(fake.read(1301) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
 
-	true
+    true
 }
 
 /// Verify the fake correctly emulates the flash hardware's behavior when a
 /// write operation tries to set a bit from 0 to 1.
 #[test]
 fn write_set_bit() -> bool {
-	use { h1b::hil::flash::Hardware, test::require };
-	let fake = h1b::hil::flash::fake::FakeHw::new();
+    use { h1b::hil::flash::Hardware, test::require };
+    let fake = h1b::hil::flash::fake::FakeHw::new();
 
-	// Operation 1: successful write.
-	fake.set_transaction(1300, 1 - 1);
-	fake.set_write_data(&[0xFFFF0FFF]);
-	fake.trigger(h1b::hil::flash::driver::WRITE_OPCODE);
-	require!(fake.is_programming() == true);
-	fake.inject_result(0);
-	require!(fake.is_programming() == false);
-	require!(fake.read_error() == 0);
-	fake.trigger(h1b::hil::flash::driver::WRITE_OPCODE);
-	require!(fake.is_programming() == true);
-	fake.finish_operation();
-	require!(fake.read_error() == 0);
-	require!(fake.is_programming() == false);
-	require!(fake.read(512) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
-	require!(fake.read(1023) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
-	require!(fake.read(1300) == ReturnCode::SuccessWithValue { value: 0xFFFF0FFF });
+    // Operation 1: successful write.
+    fake.set_transaction(1300, 1 - 1);
+    fake.set_write_data(&[0xFFFF0FFF]);
+    fake.trigger(h1b::hil::flash::driver::WRITE_OPCODE);
+    require!(fake.is_programming() == true);
+    fake.inject_result(0);
+    require!(fake.is_programming() == false);
+    require!(fake.read_error() == 0);
+    fake.trigger(h1b::hil::flash::driver::WRITE_OPCODE);
+    require!(fake.is_programming() == true);
+    fake.finish_operation();
+    require!(fake.read_error() == 0);
+    require!(fake.is_programming() == false);
+    require!(fake.read(512) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
+    require!(fake.read(1023) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
+    require!(fake.read(1300) == ReturnCode::SuccessWithValue { value: 0xFFFF0FFF });
 
-	// Operation 2: failed write. Verifies the write doesn't change anything.
-	fake.set_transaction(1300, 1 - 1);
-	fake.set_write_data(&[0x0000F000]);
-	fake.trigger(h1b::hil::flash::driver::WRITE_OPCODE);
-	require!(fake.is_programming() == true);
-	fake.inject_result(0);
-	require!(fake.is_programming() == false);
-	require!(fake.read_error() == 0);
-	fake.trigger(h1b::hil::flash::driver::WRITE_OPCODE);
-	require!(fake.is_programming() == true);
-	fake.finish_operation();
-	require!(fake.read_error() == 0x8);
-	require!(fake.is_programming() == false);
-	require!(fake.read(512) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
-	require!(fake.read(1023) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
-	require!(fake.read(1300) == ReturnCode::SuccessWithValue { value: 0xFFFF0FFF });
+    // Operation 2: failed write. Verifies the write doesn't change anything.
+    fake.set_transaction(1300, 1 - 1);
+    fake.set_write_data(&[0x0000F000]);
+    fake.trigger(h1b::hil::flash::driver::WRITE_OPCODE);
+    require!(fake.is_programming() == true);
+    fake.inject_result(0);
+    require!(fake.is_programming() == false);
+    require!(fake.read_error() == 0);
+    fake.trigger(h1b::hil::flash::driver::WRITE_OPCODE);
+    require!(fake.is_programming() == true);
+    fake.finish_operation();
+    require!(fake.read_error() == 0x8);
+    require!(fake.is_programming() == false);
+    require!(fake.read(512) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
+    require!(fake.read(1023) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
+    require!(fake.read(1300) == ReturnCode::SuccessWithValue { value: 0xFFFF0FFF });
 
-	true
+    true
 }

--- a/userspace/h1b_tests/src/hil/flash/mock_alarm.rs
+++ b/userspace/h1b_tests/src/hil/flash/mock_alarm.rs
@@ -14,29 +14,29 @@
 
 #[cfg(test)]
 pub struct MockAlarm {
-	now: core::cell::Cell<u32>,
-	setpoint: core::cell::Cell<Option<u32>>,
+    now: core::cell::Cell<u32>,
+    setpoint: core::cell::Cell<Option<u32>>,
 }
 
 #[cfg(test)]
 impl MockAlarm {
-	pub fn new() -> MockAlarm {
-		MockAlarm { now: Default::default(), setpoint: Default::default() }
-	}
+    pub fn new() -> MockAlarm {
+        MockAlarm { now: Default::default(), setpoint: Default::default() }
+    }
 
-	pub fn set_time(&self, new_time: u32) { self.now.set(new_time); }
+    pub fn set_time(&self, new_time: u32) { self.now.set(new_time); }
 }
 
 #[cfg(test)]
 impl kernel::hil::time::Time for MockAlarm {
-	type Frequency = kernel::hil::time::Freq16MHz;
-	fn disable(&self) { self.setpoint.set(None); }
-	fn is_armed(&self) -> bool { self.setpoint.get().is_some() }
+    type Frequency = kernel::hil::time::Freq16MHz;
+    fn disable(&self) { self.setpoint.set(None); }
+    fn is_armed(&self) -> bool { self.setpoint.get().is_some() }
 }
 
 #[cfg(test)]
 impl kernel::hil::time::Alarm for MockAlarm {
-	fn now(&self) -> u32 { self.now.get() }
-	fn set_alarm(&self, tics: u32) { self.setpoint.set(Some(tics)); }
-	fn get_alarm(&self) -> u32 { self.setpoint.get().unwrap_or(0) }
+    fn now(&self) -> u32 { self.now.get() }
+    fn set_alarm(&self, tics: u32) { self.setpoint.set(Some(tics)); }
+    fn get_alarm(&self) -> u32 { self.setpoint.get().unwrap_or(0) }
 }

--- a/userspace/h1b_tests/src/hil/flash/mod.rs
+++ b/userspace/h1b_tests/src/hil/flash/mod.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//mod driver;
+mod driver;
 mod fake;
 mod h1b_hw;
 mod mock_alarm;
-//mod smart_program;
+mod smart_program;

--- a/userspace/test_harness/src/assertions.rs
+++ b/userspace/test_harness/src/assertions.rs
@@ -17,10 +17,10 @@
 
 #[macro_export]
 macro_rules! require {
-	($expr:expr) => (if !$expr {
-		use core::fmt::Write;
-		let _ = writeln!(libtock::console::Console::new(), "FAILED: {}", stringify!($expr));
-		return false;
-	});
-	($expr:expr,) => (require!($expr));
+    ($expr:expr) => (if !$expr {
+        use core::fmt::Write;
+        let _ = writeln!(libtock::console::Console::new(), "FAILED: {}", stringify!($expr));
+        return false;
+    });
+    ($expr:expr,) => (require!($expr));
 }


### PR DESCRIPTION
This demonstrates that all unit tests pass on Tock 1.4-rc1.

To make h1b_tests fit, I removed a surprisingly-expensive debug! call from the flash driver. Removing the debug! call shrinks the kernel by 80 bytes and h1b_tests by 10920 bytes. After this change, h1b_tests has 8436 bytes of headroom. We need a better long-term solution to the core::fmt bloat issue.

This PR builds on #117 . New commits in this PR:

1. Remove an expensive debug statement from the flash driver and re-enab...

```
----------------------
`make prtest` summary:
----------------------
git rev-parse HEAD
171a5107dbe51648b3b982418ee2a0af0d19f8a5
git status
On branch reenable-tests
Your branch and 'origin/reenable-tests' have diverged,
and have 7 and 6 different commits each, respectively.
  (use "git pull" to merge the remote branch into yours)

nothing to commit, working tree clean
```