### PR TITLE
Increase application space to 0x40000 (256kB)

### DIFF
--- a/golf2/chip_layout.ld
+++ b/golf2/chip_layout.ld
@@ -18,7 +18,7 @@
 MEMORY
 {
   rom (rx)     : ORIGIN = 0x00044400, LENGTH = 0x00031c00
-  prog (rx)    : ORIGIN = 0x00076000, LENGTH = 0x00010000
+  prog (rx)    : ORIGIN = 0x00076000, LENGTH = 0x00040000
   ram (rwx)    : ORIGIN = 0x00010000, LENGTH = 0x00004000
   appram (rwx) : ORIGIN = 0x00014000, LENGTH = 0x0000c000
 }


### PR DESCRIPTION
This increases the application flash space to 0x40000 (256kB). It means that Tock + apps occupy both flash banks. They could easily fit in one, but given the current need for static partitioning in libtock-rs, this is a simpler approach during development.

```
----------------------
`make prtest` summary:
----------------------
git rev-parse HEAD
0a4fb243dcb9cc9f3e2908c8e9042d8e16700a3b
git status
On branch increase_app_space
Your branch is up to date with 'origin/increase_app_space'.

nothing to commit, working tree clean
```
