### PR TITLE
Fix h1b_tests so it builds.

### DIFF
--- a/userspace/h1b_tests/src/hil/flash/driver.rs
+++ b/userspace/h1b_tests/src/hil/flash/driver.rs
@@ -59,7 +59,7 @@ impl<'a> h1b::hil::flash::Client<'a> for MockClient {
 
 #[test]
 fn erase() -> bool {
-    use kernel::hil::time::Client;
+    use kernel::hil::time::{AlarmClient,Time};
     let alarm = crate::hil::flash::mock_alarm::MockAlarm::new();
     let client = MockClient::new();
     let hw = h1b::hil::flash::fake::FakeHw::new();
@@ -95,7 +95,7 @@ fn erase() -> bool {
 
 #[test]
 fn erase_max_retries() -> bool {
-    use kernel::hil::time::Client;
+    use kernel::hil::time::{AlarmClient,Time};
     let alarm = crate::hil::flash::mock_alarm::MockAlarm::new();
     let client = MockClient::new();
     let hw = h1b::hil::flash::fake::FakeHw::new();
@@ -130,7 +130,7 @@ fn erase_max_retries() -> bool {
 
 #[test]
 fn write_then_erase() -> bool {
-    use kernel::hil::time::Client;
+    use kernel::hil::time::{AlarmClient,Time};
     let alarm = crate::hil::flash::mock_alarm::MockAlarm::new();
     let client = MockClient::new();
     let hw = h1b::hil::flash::fake::FakeHw::new();
@@ -179,7 +179,7 @@ fn write_then_erase() -> bool {
 
 #[test]
 fn successful_program() -> bool {
-    use kernel::hil::time::Client;
+    use kernel::hil::time::{AlarmClient,Time};
     let alarm = crate::hil::flash::mock_alarm::MockAlarm::new();
     let client = MockClient::new();
     let hw = h1b::hil::flash::fake::FakeHw::new();
@@ -223,7 +223,7 @@ fn successful_program() -> bool {
 
 #[test]
 fn timeout() -> bool {
-    use kernel::hil::time::Client;
+    use kernel::hil::time::{AlarmClient,Time};
     let alarm = crate::hil::flash::mock_alarm::MockAlarm::new();
     let client = MockClient::new();
     let hw = h1b::hil::flash::fake::FakeHw::new();
@@ -253,7 +253,7 @@ fn timeout() -> bool {
 
 #[test]
 fn write_max_retries() -> bool {
-    use kernel::hil::time::Client;
+    use kernel::hil::time::{AlarmClient,Time};
     let alarm = crate::hil::flash::mock_alarm::MockAlarm::new();
     let client = MockClient::new();
     let hw = h1b::hil::flash::fake::FakeHw::new();

--- a/userspace/h1b_tests/src/hil/flash/mock_alarm.rs
+++ b/userspace/h1b_tests/src/hil/flash/mock_alarm.rs
@@ -12,29 +12,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(test)]
 pub struct MockAlarm {
-    now: core::cell::Cell<u32>,
+    current_time: core::cell::Cell<u32>,
     setpoint: core::cell::Cell<Option<u32>>,
 }
 
-#[cfg(test)]
 impl MockAlarm {
     pub fn new() -> MockAlarm {
-        MockAlarm { now: Default::default(), setpoint: Default::default() }
+        MockAlarm {
+            current_time: Default::default(),
+            setpoint: Default::default()
+        }
     }
 
-    pub fn set_time(&self, new_time: u32) { self.now.set(new_time); }
+    pub fn set_time(&self, new_time: u32) { self.current_time.set(new_time); }
 }
 
-#[cfg(test)]
 impl kernel::hil::time::Time for MockAlarm {
     type Frequency = kernel::hil::time::Freq16MHz;
-    fn now(&self) -> u32 { self.now.get() }
+    fn now(&self) -> u32 { self.current_time.get() }
     fn max_tics(&self) -> u32 { u32::max_value() }
 }
 
-#[cfg(test)]
 impl<'a> kernel::hil::time::Alarm<'a> for MockAlarm {
     fn set_alarm(&self, tics: u32) { self.setpoint.set(Some(tics)); }
     fn get_alarm(&self) -> u32 { self.setpoint.get().unwrap_or(0) }
@@ -43,5 +42,10 @@ impl<'a> kernel::hil::time::Alarm<'a> for MockAlarm {
     fn set_client(&'a self, _client: &'a dyn kernel::hil::time::AlarmClient) {}
 
     fn is_enabled(&self) -> bool { self.setpoint.get().is_some() }
+
+    fn enable(&self) {
+        if self.setpoint.get().is_none() { self.setpoint.set(Some(0)); }
+    }
+
     fn disable(&self) { self.setpoint.set(None); }
 }


### PR DESCRIPTION
PR #118 (Reenable flash unit tests) and PR #115 (Update Tock to 1.4-rc1) were developed independently and not tested together. The test functionality re-enabled in PR #118 needed to be updated to work with the new Time HIL. This performs that update so that h1b_tests builds again.

```
----------------------
`make prtest` summary:
----------------------
git rev-parse HEAD
af8d212e398dddb6522e7ec4d31f75db964085fb
git status
On branch build-fix
nothing to commit, working tree clean
```
