### PR TITLE
Restore gap in GPIO register file.

### DIFF
--- a/h1b/src/gpio.rs
+++ b/h1b/src/gpio.rs
@@ -22,9 +22,10 @@ use kernel::hil;
 pub struct PortRegisters {
     pub data_in: VolatileCell<u32>,
     pub data_out: VolatileCell<u32>,
+    _reserved: [u32; 2],
     pub output_enable: VolatileCell<u32>,
     pub output_disable: VolatileCell<u32>,
-    _reserved: [u32; 2],
+    _reserved2: [u32; 2],
     pub interrupt_enable: VolatileCell<u32>,
     pub interrupt_disable: VolatileCell<u32>,
     pub interrupt_type_set: VolatileCell<u32>,


### PR DESCRIPTION
Restores the necessary gap between GPIO_DOUT and GPIO_SETDOUTEN.
	
```
----------------------
`make prtest` summary:
----------------------
git rev-parse HEAD
f9dd3a2f8d905225f8e37583f7ab4763b9e20830
git status
On branch gpio-reg-fix
Your branch is up to date with 'origin/gpio-reg-fix'.

nothing to commit, working tree clean
```
