### PR TITLE
Add a version check on Cargo.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,4 +53,17 @@ prtest: build devicetests localtests
 	@echo '```'
 
 
+# A target that prints an error message and fails the build if the cargo version
+# is not sufficiently up-to-date.
+.PHONY: cargo_version_check
+cargo_version_check:
+	min_version="1.37.0" ; \
+	cargo_version="$$(cargo -V | awk '{ print $$2 }')" ; \
+	if [ "$$(third_party/tock/tools/semver.sh $${cargo_version} \< $${min_version})" != "false" ] ; \
+		then echo "#######################################################################"; \
+		     echo "# Please update your stable toolchain. Minimum version: $${min_version}"; \
+		     echo "#######################################################################"; \
+		     exit 1; \
+		fi
+
 include $(addsuffix /Build.mk,$(BUILD_SUBDIRS))

--- a/third_party/Build.mk
+++ b/third_party/Build.mk
@@ -24,7 +24,7 @@
 third_party/build: build/cargo-host/release/elf2tab
 
 .PHONY: third_party/check
-third_party/check:
+third_party/check: cargo_version_check
 	cd third_party/elf2tab && \
 		CARGO_BUILD_TARGET_DIR="../../build/cargo-host" \
 		cargo check --frozen --release
@@ -36,7 +36,7 @@ third_party/check:
 third_party/devicetests:
 
 .PHONY: third_party/doc
-third_party/doc:
+third_party/doc: cargo_version_check
 	cd third_party/elf2tab && \
 		CARGO_BUILD_TARGET_DIR="../../build/cargo-host" \
 		cargo doc --frozen --release
@@ -45,7 +45,7 @@ third_party/doc:
 		cargo doc --offline --release
 
 .PHONY: third_party/localtests
-third_party/localtests:
+third_party/localtests: cargo_version_check
 	cd third_party/elf2tab && \
 		CARGO_BUILD_TARGET_DIR="../../build/cargo-host" \
 		cargo test --frozen --release
@@ -55,7 +55,7 @@ third_party/localtests:
 
 
 .PHONY: build/cargo-host/release/elf2tab
-build/cargo-host/release/elf2tab:
+build/cargo-host/release/elf2tab: cargo_version_check
 	cd third_party/elf2tab && \
 		CARGO_BUILD_TARGET_DIR="../../build/cargo-host" \
 		cargo build --frozen --release

--- a/tools/Build.mk
+++ b/tools/Build.mk
@@ -13,20 +13,20 @@
 # limitations under the License.
 
 .PHONY: tools/build
-tools/build:
+tools/build: cargo_version_check
 	cd tools && cargo build --offline --release
 
 .PHONY: tools/check
-tools/check:
+tools/check: cargo_version_check
 	cd tools && cargo check --offline --release
 
 .PHONY: tools/devicetests
 tools/devicetests:
 
 .PHONY: tools/doc
-tools/doc:
+tools/doc: cargo_version_check
 	cd tools && cargo doc --offline --release
 
 .PHONY: tools/localtests
-tools/localtests:
+tools/localtests: cargo_version_check
 	cd tools && cargo test --offline --release


### PR DESCRIPTION
This is to avoid hard-to-diagnose errors related to unrecognized flags. Note that this checks the rustc version as well (for the stable toolchain).

```
----------------------
`make prtest` summary:
----------------------
git rev-parse HEAD
a39150d02a8727abba062b16944f61312635334b
git status
On branch cargo-version-check
Your branch is up to date with 'origin/cargo-version-check'.

nothing to commit, working tree clean
```
