### PR TITLE
Remove redundant client set.

### DIFF
--- a/golf2/src/main.rs
+++ b/golf2/src/main.rs
@@ -443,7 +443,6 @@ pub unsafe fn reset_handler() {
     //nvcounter_test.run();
 
     // Uncomment to initialize NvCounter
-    nvcounter.set_client(nvcounter_syscall);
     //nvcounter_syscall.initialize();
 
 


### PR DESCRIPTION
Client was already set in line 297. Nice catch by @jrvanwhy 
```
----------------------
`make prtest` summary:
----------------------
git rev-parse HEAD
31a36efe0d92ef5e45ce5ebd3a2c70b6ccc40a42
git status
On branch nvcounter-syscall-cleanup
Your branch is up to date with 'origin/nvcounter-syscall-cleanup'.

nothing to commit, working tree clean
```
