### PR TITLE
Add a low-level-debug test app.

### DIFF
--- a/golf2/src/debug_syscall.rs
+++ b/golf2/src/debug_syscall.rs
@@ -23,7 +23,9 @@
 
 use kernel::{AppId, Driver, ReturnCode};
 
-pub const DRIVER_NUM: usize = 0x80000001;
+// Matched to LowLevelDebug until Tock 1.5 is released.
+// TODO: When we update to Tock 1.5, replace UintPrinter with LowLevelDebug.
+pub const DRIVER_NUM: usize = 0x00008;
 pub struct UintPrinter {}
 
 impl UintPrinter {

--- a/userspace/Build.mk
+++ b/userspace/Build.mk
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 BUILD_SUBDIRS := $(addprefix userspace/,aes_test dcrypto_test flash_test gpio_test \
-		nvcounter_test nvcounter_ctest personality_clear personality_test sha_test \
-		spin u2f_app u2f_test )
+		low_level_debug nvcounter_test nvcounter_ctest personality_clear \
+		personality_test sha_test spin u2f_app u2f_test )
 
 .PHONY: userspace/build
 userspace/build: $(addsuffix /build,$(BUILD_SUBDIRS))
@@ -102,6 +102,90 @@ $(foreach APP,$(C_APPS),build/userspace/$(APP)/full_image): \
 		build/userspace/$*/unsigned_image
 	arm-none-eabi-objcopy --update-section \
 		.apps=build/userspace/$*/cortex-m3/cortex-m3.tbf \
+		build/userspace/$*/unsigned_image
+	$(TANGO_CODESIGNER) --b --input build/userspace/$*/unsigned_image \
+		--key=$(TANGO_CODESIGNER_KEY) \
+		--output=build/userspace/$*/signed_image
+	cat $(TANGO_BOOTLOADER) build/userspace/$*/signed_image \
+		> build/userspace/$*/full_image
+
+# ------------------------------------------------------------------------------
+# Build rules shared between Rust app targets. These are not used for Rust test
+# apps, which are handled below.
+# ------------------------------------------------------------------------------
+
+# These are static pattern rules, see above (the C apps rules) section for an
+# explanation.
+
+.PHONY: $(foreach APP,$(RUST_APPS),userspace/$(APP)/build)
+$(foreach APP,$(RUST_APPS),userspace/$(APP)/build): userspace/%/build: \
+		build/userspace/%/full_image
+
+.PHONY: $(foreach APP,$(RUST_APPS),userspace/$(APP)/check)
+$(foreach APP,$(RUST_APPS),userspace/$(APP)/check): userspace/%/check:
+	cd userspace/$* && TOCK_KERNEL_VERSION=$* cargo check \
+		--offline --release
+
+.PHONY: $(foreach APP,$(RUST_APPS),userspace/$(APP)/devicetests)
+$(foreach APP,$(RUST_APPS),userspace/$(APP)/devicetests):
+
+.PHONY: $(foreach APP,$(RUST_APPS),userspace/$(APP)/doc)
+$(foreach APP,$(RUST_APPS),userspace/$(APP)/doc): userspace/%/doc:
+	cd userspace/$* && TOCK_KERNEL_VERSION=$* cargo doc --offline --release
+
+.PHONY: $(foreach APP,$(RUST_APPS),userspace/$(APP)/localtests)
+$(foreach APP,$(RUST_APPS),userspace/$(APP)/localtests):
+
+.PHONY: $(foreach APP,$(RUST_APPS),userspace/$(APP)/program)
+$(foreach APP,$(RUST_APPS),userspace/$(APP)/program): userspace/%/program: \
+		build/userspace/%/full_image
+	flock build/device_lock -c '$(TANGO_SPIFLASH) --verbose \
+		--input=build/userspace/$*/full_image'
+
+.PHONY: $(foreach APP,$(RUST_APPS),userspace/$(APP)/run)
+$(foreach APP,$(RUST_APPS),userspace/$(APP)/run): userspace/%/run: \
+		build/cargo-host/release/runner build/userspace/%/full_image
+	flock build/device_lock -c ' \
+		$(TANGO_SPIFLASH) --verbose \
+		                  --input=build/userspace/$*/full_image ; \
+		stty -F /dev/ttyUltraConsole3 115200 -echo ; \
+		stty -F /dev/ttyUltraTarget2 115200 -icrnl ; \
+		build/cargo-host/release/runner'
+
+.PHONY: $(foreach APP,$(RUST_APPS),build/userspace/$(APP)/app)
+$(foreach APP,$(RUST_APPS),build/userspace/$(APP)/app): build/userspace/%/app:
+	rm -f build/userspace/cargo/thumbv7m-none-eabi/release/$*-*
+	cd userspace/$* && TOCK_KERNEL_VERSION=$* cargo build --offline --release
+	mkdir -p build/userspace/$*/
+	cp "build/userspace/cargo/thumbv7m-none-eabi/release/$*" \
+		"build/userspace/$*/app"
+
+# Due to b/139156455, we want to detect the case where an application's size is
+# rounded up to 64 KiB.
+$(foreach APP,$(RUST_APPS),build/userspace/$(APP)/app.tbf): \
+		build/userspace/%/app.tbf: \
+		build/cargo-host/release/elf2tab build/userspace/%/app
+	build/cargo-host/release/elf2tab -n "$(notdir $*)" \
+		-o build/userspace/$*/app_tab \
+		build/userspace/$*/app --stack=2048 --app-heap=1024 \
+		--kernel-heap=1024 --protected-region-size=64
+	if [ "$$(wc -c <build/userspace/$*/app.tbf)" -ge 65536 ]; \
+		then echo "#########################################################"; \
+		     echo "# Application $(notdir $*) is too large."; \
+		     echo "# Check size of build/userspace/$*/app.tbf"; \
+		     echo "#########################################################"; \
+		     false ; \
+		fi
+
+$(foreach APP,$(RUST_APPS),build/userspace/$(APP)/full_image): \
+		build/userspace/%/full_image: build/userspace/%/app.tbf \
+		golf2/target/thumbv7m-none-eabi/release/golf2 ;
+	cp golf2/target/thumbv7m-none-eabi/release/golf2 \
+		build/userspace/$*/unsigned_image
+	arm-none-eabi-objcopy --set-section-flags .apps=alloc,code,contents \
+		build/userspace/$*/unsigned_image
+	arm-none-eabi-objcopy --update-section \
+		.apps=build/userspace/$*/app.tbf \
 		build/userspace/$*/unsigned_image
 	$(TANGO_CODESIGNER) --b --input build/userspace/$*/unsigned_image \
 		--key=$(TANGO_CODESIGNER_KEY) \

--- a/userspace/Cargo.toml
+++ b/userspace/Cargo.toml
@@ -42,6 +42,7 @@ panic = "unwind"
 [workspace]
 members = [
 	"flash_test",
+	"low_level_debug",
 	"nvcounter_test",
 	"test_harness",
 ]

--- a/userspace/low_level_debug/Build.mk
+++ b/userspace/low_level_debug/Build.mk
@@ -1,0 +1,15 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+RUST_APPS += low_level_debug

--- a/userspace/low_level_debug/Cargo.toml
+++ b/userspace/low_level_debug/Cargo.toml
@@ -1,0 +1,23 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[package]
+name = "low_level_debug"
+version = "0.1.0"
+authors = ["jrvanwhy <jrvanwhy@google.com>"]
+edition = "2018"
+publish = false
+
+[dependencies]
+libtock = { path = "../../third_party/libtock-rs" }

--- a/userspace/low_level_debug/Makefile
+++ b/userspace/low_level_debug/Makefile
@@ -1,0 +1,17 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+INVOKE_DIR    := userspace/low_level_debug
+TOCK_ON_TITAN := ../..
+include $(TOCK_ON_TITAN)/DirShim.mk

--- a/userspace/low_level_debug/src/main.rs
+++ b/userspace/low_level_debug/src/main.rs
@@ -1,0 +1,46 @@
+// Copyright 2019 Google LLC
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     https://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![no_std]
+
+// Note: this currently calls into UintPrinter, not LowLevelDebug. When Tock 1.5
+// is released, we should replace UintPrinter with LowLevelDebug in golf2, at
+// which point this app will work correctly.
+
+fn main() {
+    // LowLevelDebug: App 0x0 prints 0x123
+    libtock::debug::low_level_print1(0x123);
+
+    // LowLevelDebug: App 0x0 prints 0x456 0x789
+    libtock::debug::low_level_print2(0x456, 0x789);
+
+    // Print a series of messages quickly to overfill the queue and demonstrate
+    // the message drop behavior.
+    for _ in 0..10 {
+        libtock::debug::low_level_print1(0x1);
+        libtock::debug::low_level_print2(0x2, 0x3);
+    }
+
+    // Wait for the above to print then output a few more messages.
+    libtock::timer::sleep(libtock::timer::Duration::from_ms(100));
+
+    // LowLevelDebug: App 0x0 prints 0xA
+    libtock::debug::low_level_print1(0xA);
+
+    // LowLevelDebug: App 0x0 prints 0xB 0xC
+    libtock::debug::low_level_print2(0xB, 0xC);
+
+    // LowLevelDebug: App 0x0 status code 0x1
+    panic!()
+}


### PR DESCRIPTION
Until Tock 1.5 is released, this will call into UintPrinter instead of LowLevelDebug. When Tock 1.5 is released, we'll replace UintPrinter with LowLevelDebug.

```
----------------------
`make prtest` summary:
----------------------
git rev-parse HEAD
94282b92e893344a5b2bd403798eb74d306b3ebd
git status
On branch low-level-debug
Your branch is up to date with 'origin/low-level-debug'.

nothing to commit, working tree clean
```