### PR TITLE
This adds an optional alarm test to the golf2 boot. 

### DIFF
--- a/golf2/Cargo.toml
+++ b/golf2/Cargo.toml
@@ -33,8 +33,7 @@ debug = true
 
 [dependencies]
 capsules = { path = "../third_party/tock/capsules" }
+components = { path = "../third_party/tock/boards/components" }
 kernel = { path = "../third_party/tock/kernel" }
 cortexm3 = { path = "../third_party/tock/arch/cortex-m3" }
 h1b = { path = "../h1b" }
-
-

--- a/golf2/src/alarm_test.rs
+++ b/golf2/src/alarm_test.rs
@@ -1,0 +1,31 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use capsules::test::alarm::TestAlarm;
+use kernel::hil::time::Alarm;
+use h1b::timels;
+#[allow(unused_imports)]
+
+pub unsafe fn run_alarm() {
+    let r = static_init_test_alarm();
+    timels::TIMELS0.set_client(r);
+    r.run();
+}
+
+unsafe fn static_init_test_alarm() -> &'static mut TestAlarm<'static, timels::Timels> {
+    static_init!(
+        TestAlarm<'static, timels::Timels>,
+        TestAlarm::new(&timels::TIMELS0)
+    )
+}


### PR DESCRIPTION
It is mostly a demonstration of how to test the alarm using the new
TestAlarm; we should block on merging until that is merged into
mainline Tock.

**Remember to run `make prtest` and paste the output here (replace this line)**

Make prtest failed on 
```
make[1]: Leaving directory '/usr/local/google/home/plevis/src/tock-on-titan/userspace/dcrypto_test'
cp golf2/target/thumbv7m-none-eabi/release/golf2 \
	build/userspace/dcrypto_test/unsigned_image
arm-none-eabi-objcopy --set-section-flags .apps=alloc,code,contents \
	build/userspace/dcrypto_test/unsigned_image
arm-none-eabi-objcopy --update-section \
	.apps=build/userspace/dcrypto_test/cortex-m3/cortex-m3.tbf \
	build/userspace/dcrypto_test/unsigned_image
/usr/local/google/home/plevis/bin/codesigner --b --input build/userspace/dcrypto_test/unsigned_image \
	--key=/usr/local/google/home/plevis/src/bootloaders/phil-testkey-A.pem \
	--output=build/userspace/dcrypto_test/signed_image
cat /usr/local/google/home/plevis/src/bootloaders/42595.hex build/userspace/dcrypto_test/signed_image \
	> build/userspace/dcrypto_test/full_image
rm -f build/userspace/cargo/thumbv7m-none-eabi/release/flash_test-*
cd userspace/flash_test && TOCK_KERNEL_VERSION=flash_test \
	cargo test --no-run --offline --release
error: failed to read `/usr/local/google/home/plevis/src/tock-on-titan/third_party/libtock-rs/async-support/Cargo.toml`

```
