### PR TITLE
Sandbox fixes (libtock-rs Cargo.toml and directory fix).

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,13 +19,16 @@ BUILD_SUBDIRS := kernel runner third_party tools userspace
 # installing things during builds. We don't like that. This is a sandbox we can
 # run commands in that denies network access as well as write access outside the
 # build/ directory.
-BWRAP := bwrap                                 \
-         --ro-bind / /                         \
-         --bind "$(PWD)/build" "$(PWD)/build"  \
-         --bind "$(PWD)/kernel/Cargo.lock" "$(PWD)/kernel/Cargo.lock"  \
-         --bind "$(PWD)/userspace/Cargo.lock" "$(PWD)/userspace/Cargo.lock"  \
-         --dev /dev                            \
-         --tmpfs /tmp                          \
+BWRAP := bwrap                                                               \
+         --ro-bind / /                                                       \
+         --bind "$(CURDIR)/build" "$(CURDIR)/build"                          \
+         --bind "$(CURDIR)/kernel/Cargo.lock" "$(CURDIR)/kernel/Cargo.lock"  \
+         --bind "$(CURDIR)/userspace/Cargo.lock"                             \
+                "$(CURDIR)/userspace/Cargo.lock"                             \
+         --bind "$(CURDIR)/third_party/libtock-rs/Cargo.lock"                \
+                "$(CURDIR)/third_party/libtock-rs/Cargo.lock"                \
+         --dev /dev                                                          \
+         --tmpfs /tmp                                                        \
          --unshare-all
 
 .PHONY: all


### PR DESCRIPTION
1. Add libtock-rs' Cargo.lock to the list of writable files. I'm not sure why
   this omission wasn't caught by my previous `make prtest`.
2. Use $(CURDIR) instead of $(PWD). Evidently when you run `make` from
   third_party/, $(PWD) becomes third_party/ while $(CURDIR) is
   tock-on-titan/ (which is what we want for the sandbox).

```
----------------------
`make prtest` summary:
----------------------
git rev-parse HEAD
a9a941a90eada194db8411df5254a7e849d5a2d2
git status
On branch bwrap_fix
nothing to commit, working tree clean
```