### PR TITLE
Fix build to work from scratch.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,11 +57,7 @@ check: $(addsuffix /check,$(BUILD_SUBDIRS))
 
 # No need to recurse into most directories, as rm does that for us.
 .PHONY: clean
-clean: kernel/clean userspace/clean
-	rm -f runner/Cargo.lock
-	rm -f third_party/libtock-rs/Cargo.lock
-	rm -f third_party/rustc-demangle/Cargo.lock
-	rm -f tools/Cargo.lock
+clean: kernel/clean runner/clean third_party/clean tools/clean userspace/clean
 	rm -rf build/
 
 .PHONY: devicetests

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,8 @@ BWRAP := bwrap                                                               \
          --bind "$(CURDIR)/runner/Cargo.lock" "$(CURDIR)/runner/Cargo.lock"  \
          --bind "$(CURDIR)/third_party/libtock-rs/Cargo.lock"                \
                 "$(CURDIR)/third_party/libtock-rs/Cargo.lock"                \
+         --bind "$(CURDIR)/third_party/rustc-demangle/Cargo.lock"            \
+                "$(CURDIR)/third_party/rustc-demangle/Cargo.lock"            \
          --bind "$(CURDIR)/tools/Cargo.lock" "$(CURDIR)/tools/Cargo.lock"    \
          --bind "$(CURDIR)/userspace/Cargo.lock"                             \
                 "$(CURDIR)/userspace/Cargo.lock"                             \
@@ -43,6 +45,7 @@ sandbox_setup:
 	>>kernel/Cargo.lock
 	>>runner/Cargo.lock
 	>>third_party/libtock-rs/Cargo.lock
+	>>third_party/rustc-demangle/Cargo.lock
 	>>tools/Cargo.lock
 	>>userspace/Cargo.lock
 
@@ -57,6 +60,7 @@ check: $(addsuffix /check,$(BUILD_SUBDIRS))
 clean: kernel/clean userspace/clean
 	rm -f runner/Cargo.lock
 	rm -f third_party/libtock-rs/Cargo.lock
+	rm -f third_party/rustc-demangle/Cargo.lock
 	rm -f tools/Cargo.lock
 	rm -rf build/
 

--- a/runner/Build.mk
+++ b/runner/Build.mk
@@ -20,6 +20,10 @@ runner/check: sandbox_setup
 	cd runner && \
 		CARGO_TARGET_DIR="../build/cargo-host" $(BWRAP) cargo check
 
+.PHONY: kernel/clean
+runner/clean:
+	rm -f runner/Cargo.lock
+
 .PHONY: runner/devicetests
 runner/devicetests:
 

--- a/third_party/Build.mk
+++ b/third_party/Build.mk
@@ -38,6 +38,11 @@ third_party/check: cargo_version_check sandbox_setup
 		CARGO_TARGET_DIR="../../build/cargo-host" \
 		$(BWRAP) cargo check --offline --release
 
+.PHONY: third_party/clean
+third_party/clean:
+	rm -f third_party/libtock-rs/Cargo.lock
+	rm -f third_party/rustc-demangle/Cargo.lock
+
 .PHONY: third_party/devicetests
 third_party/devicetests:
 

--- a/tools/Build.mk
+++ b/tools/Build.mk
@@ -20,6 +20,10 @@ tools/build: cargo_version_check sandbox_setup
 tools/check: cargo_version_check sandbox_setup
 	cd tools && $(BWRAP) cargo check --offline --release
 
+.PHONY: tools/clean
+tools/clean:
+	rm -f tools/Cargo.lock
+
 .PHONY: tools/devicetests
 tools/devicetests:
 

--- a/userspace/CAppMakefile.mk
+++ b/userspace/CAppMakefile.mk
@@ -21,6 +21,9 @@ APP_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))$(APP)
 ELF2TAB := ../../build/cargo-host/release/elf2tab
 TOCK_ARCHS := cortex-m3
 TOCK_USERLAND_BASE_DIR = $(APP_DIR)/../../third_party/libtock-c
+chromiumos-ec_BUILDDIR = $(APP_DIR)/../../build/chromiumos-ec
+libtock_BUILDDIR = $(APP_DIR)/../../build/libtock
+libh1_BUILDDIR = $(APP_DIR)/../../build/libh1
 BUILDDIR ?= $(APP_DIR)/../../build/userspace/$(APP)
 
 C_SRCS   := $(wildcard *.c)


### PR DESCRIPTION
- Create missing Cargo.lock files.
- Add missing bind parameters for bwrap.
- Set libtock-c $(LIBNAME)_BUILDDIR variables.

This requires libtock-c at commit
c186cfcd520c669700a469daf776d4266137aef4 or later.

Confirmed that `make prtest` still runs.