### PR TITLE
Add a GitHub action that runs `make check localtests`.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,55 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: ci
+on: pull_request
+
+jobs:
+  build:
+    # Using ubuntu-latest can cause breakage when ubuntu-latest is updated to
+    # point at a new Ubuntu version. Instead, explicitly specify the version, so
+    # we can update when we need to. This *could* break if we don't update it
+    # until support for 18.04 is dropped, but it is likely we'll have a reason
+    # to update to a newer Ubuntu before then anyway.
+    runs-on: ubuntu-18.04
+
+    steps:
+      # Clones a single commit from the repository. The commit cloned is a merge
+      # commit between the PR's target branch and the PR's source.
+      - name: Clone repository
+        uses: actions/checkout@v2.3.1
+
+      # Update the submodules. We can't update all submodules because the
+      # shared-ci submodule is not publicly accessible.
+      - name: Update submodules
+        run: |
+          git submodule update --init \
+            third_party/{elf2tab,libtock-c,libtock-rs,tock}
+
+      # Run `make setup` to install the necessary Rust toolchains.
+      - name: Make setup
+        run: make -C "${GITHUB_WORKSPACE}" setup
+
+      # Install the bubblewrap sandboxing tool.
+      - name: Install Bubblewrap
+        run: sudo apt-get install bubblewrap
+
+      # Runs the `check` and `localtests` make actions. We cannot build this
+      # repository in GitHub Actions as building requires non-publicly-available
+      # code signing tools, so this is the best we can do (at least for now --
+      # theoretically we could build up until the code signing step but the
+      # makefiles are not structured for that yet). I use -j2 because the VMs
+      # that GitHub Actions uses have 2 logical CPUs.
+      - name: Check and local tests
+        run: make -C "${GITHUB_WORKSPACE}" -j2 check localtests

--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,18 @@ prtest: build devicetests localtests
 	git status
 	@echo '```'
 
+# Installs the necessary Rust toolchains
+.PHONY: setup
+setup:
+	rustup toolchain add --profile minimal \
+		"$$(cat third_party/libtock-rs/rust-toolchain)"
+	rustup toolchain add --profile minimal \
+		"$$(cat third_party/tock/rust-toolchain)"
+	rustup target add --toolchain \
+		"$$(cat third_party/libtock-rs/rust-toolchain)" thumbv7m-none-eabi
+	rustup target add --toolchain \
+		"$$(cat third_party/tock/rust-toolchain)" thumbv7m-none-eabi
+
 
 # A target that prints an error message and fails the build if the cargo version
 # is not sufficiently up-to-date.


### PR DESCRIPTION
Unfortunately, we cannot run `make build` without access to a Google-internal code signing tool. `make check localtests` is the next-best option available to us that doesn't require making large changes to the build system.

I added a `make setup` target that sets up the corresponding toolchains.

```
----------------------
`make prtest` summary:
----------------------
git rev-parse HEAD
948e96c7ddd89682fab5c346bd8726152bdf967b
git status
On branch action
Your branch is up to date with 'origin/action'.

nothing to commit, working tree clean
```