### PR TITLE
Use bubblewrap to replace elf2tab's Cargo.lock with a new empty one.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,8 @@ BUILD_SUBDIRS := kernel runner third_party tools userspace
 BWRAP := bwrap                                                               \
          --ro-bind / /                                                       \
          --bind "$(CURDIR)/build" "$(CURDIR)/build"                          \
+         --bind "$(CURDIR)/build/Cargo.lock/elf2tab"                         \
+                "$(CURDIR)/third_party/elf2tab/Cargo.lock"                   \
          --bind "$(CURDIR)/kernel/Cargo.lock" "$(CURDIR)/kernel/Cargo.lock"  \
          --bind "$(CURDIR)/runner/Cargo.lock" "$(CURDIR)/runner/Cargo.lock"  \
          --bind "$(CURDIR)/third_party/libtock-rs/Cargo.lock"                \
@@ -41,7 +43,8 @@ BWRAP := bwrap                                                               \
 # A target that sets up directories the bwrap sandbox needs.
 .PHONY: sandbox_setup
 sandbox_setup:
-	mkdir -p build
+	mkdir -p build/Cargo.lock
+	>>build/Cargo.lock/elf2tab
 	>>kernel/Cargo.lock
 	>>runner/Cargo.lock
 	>>third_party/libtock-rs/Cargo.lock

--- a/third_party/Build.mk
+++ b/third_party/Build.mk
@@ -29,8 +29,7 @@ third_party/build: build/cargo-host/release/elf2tab sandbox_setup
 .PHONY: third_party/check
 third_party/check: cargo_version_check sandbox_setup
 	cd third_party/elf2tab && \
-		CARGO_TARGET_DIR="../../build/cargo-host" \
-		$(BWRAP) cargo check --frozen --release
+		CARGO_TARGET_DIR="../../build/cargo-host" $(BWRAP) cargo check --release
 	cd third_party/libtock-rs && \
 		CARGO_TARGET_DIR="../../build/userspace/cargo" \
 		$(BWRAP) cargo check --offline --release --target=thumbv7m-none-eabi --examples
@@ -49,8 +48,7 @@ third_party/devicetests:
 .PHONY: third_party/doc
 third_party/doc: cargo_version_check sandbox_setup
 	cd third_party/elf2tab && \
-		CARGO_TARGET_DIR="../../build/cargo-host" \
-		$(BWRAP) cargo doc --frozen --release
+		CARGO_TARGET_DIR="../../build/cargo-host" $(BWRAP) cargo doc --release
 	cd third_party/rustc-demangle && \
 		CARGO_TARGET_DIR="../../build/cargo-host" \
 		$(BWRAP) cargo doc --offline --release
@@ -58,8 +56,7 @@ third_party/doc: cargo_version_check sandbox_setup
 .PHONY: third_party/localtests
 third_party/localtests: cargo_version_check sandbox_setup
 	cd third_party/elf2tab && \
-		CARGO_TARGET_DIR="../../build/cargo-host" \
-		$(BWRAP) cargo test --frozen --release
+		CARGO_TARGET_DIR="../../build/cargo-host" $(BWRAP) cargo test --release
 	cd third_party/libtock-rs && \
 		CARGO_TARGET_DIR="../../build/cargo-host" \
 		$(BWRAP) cargo test --lib --offline --release
@@ -71,5 +68,4 @@ third_party/localtests: cargo_version_check sandbox_setup
 .PHONY: build/cargo-host/release/elf2tab
 build/cargo-host/release/elf2tab: cargo_version_check sandbox_setup
 	cd third_party/elf2tab && \
-		CARGO_TARGET_DIR="../../build/cargo-host" \
-		$(BWRAP) cargo build --frozen --release
+		CARGO_TARGET_DIR="../../build/cargo-host" $(BWRAP) cargo build --release


### PR DESCRIPTION
This effectively disables cargo's reproducible build mechanism, allowing us to modify elf2tab's dependencies. This will allow us to remove many dependencies that we don't need (such as winapi) by patching dependencies' Cargo.toml files. It will also improve our ability to deduplicate different versions of a crate, because we will no longer need to match crate checksums to elf2tab's Cargo.lock.

```
----------------------
`make prtest` summary:
----------------------
git rev-parse HEAD
73537c5c76010d739b3e20f81546a643f57125cb
git status
On branch cargo-lock-hack
nothing to commit, working tree clean
```