### PR TITLE
Reset the Cargo.lock files on each build.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,13 +44,13 @@ BWRAP := bwrap                                                               \
 .PHONY: sandbox_setup
 sandbox_setup:
 	mkdir -p build/Cargo.lock
-	>>build/Cargo.lock/elf2tab
-	>>kernel/Cargo.lock
-	>>runner/Cargo.lock
-	>>third_party/libtock-rs/Cargo.lock
-	>>third_party/rustc-demangle/Cargo.lock
-	>>tools/Cargo.lock
-	>>userspace/Cargo.lock
+	>build/Cargo.lock/elf2tab
+	>kernel/Cargo.lock
+	>runner/Cargo.lock
+	>third_party/libtock-rs/Cargo.lock
+	>third_party/rustc-demangle/Cargo.lock
+	>tools/Cargo.lock
+	>userspace/Cargo.lock
 
 .PHONY: build
 build: $(addsuffix /build,$(BUILD_SUBDIRS))


### PR DESCRIPTION
`cargo` stashes persistent data in its lockfiles, and sometimes errors out rather than regenerating those files when the sources change. In particular, if I touch a .cargo-checksums.json file under third_party/ `cargo` complains rather than fixing its Cargo.lock files.

This change empties the Cargo.lock files on each build to prevent `cargo` from erroring out.

```
----------------------
`make prtest` summary:
----------------------
git rev-parse HEAD
6448fc166fed0d594f20a336ca691384e8b98605
git status
On branch reset-cargo-lock
nothing to commit, working tree clean
```
