### PR TITLE
Add support to handle SPI device address mode change in kernel

### DIFF
--- a/kernel/h1_syscalls/src/spi_device.rs
+++ b/kernel/h1_syscalls/src/spi_device.rs
@@ -13,7 +13,11 @@ use kernel::Grant;
 use kernel::ReturnCode;
 use kernel::Shared;
 
+use spiutils::driver::HandlerMode;
 use spiutils::protocol::flash::AddressMode;
+use spiutils::protocol::flash::OpCode;
+use spiutils::protocol::wire::FromWireError;
+use spiutils::protocol::wire::WireEnum;
 
 pub const DRIVER_NUM: usize = 0x40030;
 
@@ -22,6 +26,8 @@ pub struct AppData {
     tx_buffer: Option<AppSlice<Shared, u8>>,
     rx_buffer: Option<AppSlice<Shared, u8>>,
     data_received_callback: Option<Callback>,
+    address_mode_handling: Cell<HandlerMode>,
+    address_mode_changed_callback: Option<Callback>,
 }
 
 /// The virtual base address of the external flash
@@ -96,6 +102,44 @@ impl<'a> SpiDeviceSyscall<'a> {
             ReturnCode::SuccessWithValue { value: self.device.get_address_mode() as usize }
         }).unwrap_or(ReturnCode::ENOMEM)
     }
+
+    fn set_address_mode_handling(&self, caller_id: AppId, address_mode_handling: HandlerMode) -> ReturnCode {
+        self.apps.enter(caller_id, |app_data, _| {
+            app_data.address_mode_handling.set(address_mode_handling);
+            ReturnCode::SUCCESS
+        }).unwrap_or(ReturnCode::ENOMEM)
+    }
+
+    fn process_spi_cmd(&self, app_data: &AppData, spi_cmd: u8) -> Result<HandlerMode, FromWireError> {
+        let op_code = OpCode::from_wire_value(spi_cmd).ok_or(FromWireError::OutOfRange)?;
+
+        match op_code {
+            OpCode::Enter4ByteAddressMode | OpCode::Exit4ByteAddressMode =>
+                match app_data.address_mode_handling.get() {
+                    HandlerMode::KernelSpace => {
+                        let address_mode = match op_code {
+                            OpCode::Enter4ByteAddressMode => AddressMode::FourByte,
+                            OpCode::Exit4ByteAddressMode => AddressMode::ThreeByte,
+                            _ => return Err(FromWireError::OutOfRange)
+                        };
+                        let mut has_address_mode_changed = false;
+                        if self.device.get_address_mode() != address_mode {
+                            self.device.set_address_mode(address_mode);
+                            has_address_mode_changed = true;
+                        }
+                        self.device.clear_busy();
+                        if has_address_mode_changed {
+                            app_data.address_mode_changed_callback.map(
+                                |mut cb| cb.schedule(usize::from(address_mode), 0, 0));
+                        }
+                        Ok(HandlerMode::KernelSpace)
+                    }
+                    handler_mode => Ok(handler_mode)
+                },
+            _ => Ok(HandlerMode::UserSpace)
+        }
+    }
+
 }
 
 impl<'a> SpiDeviceClient for SpiDeviceSyscall<'a> {
@@ -104,11 +148,34 @@ impl<'a> SpiDeviceClient for SpiDeviceSyscall<'a> {
         self.current_user.get().map(|current_user| {
             let _ = self.apps.enter(current_user, move |app_data, _| {
                 let mut rx_len = 0;
+                let mut handler_mode = HandlerMode::UserSpace;
+                let mut maybe_spi_cmd : Option<u8> = None;
                 if let Some(ref mut rx_buffer) = app_data.rx_buffer {
                     rx_len = self.device.get_received_data(rx_buffer.as_mut());
+                    if rx_len > 0 {
+                        maybe_spi_cmd = Some(rx_buffer.as_ref()[0]);
+                    }
+                } else {
+                    // Just grab the first byte
+                    let mut spi_cmd_buf = [0];
+                    let spi_cmd_buf_len = self.device.get_received_data(&mut spi_cmd_buf);
+                    if spi_cmd_buf_len > 0 {
+                        maybe_spi_cmd = Some(spi_cmd_buf[0]);
+                    }
                 }
-                app_data.data_received_callback.map(
-                    |mut cb| cb.schedule(rx_len, usize::from(is_busy), 0));
+
+                // Handle some special op code straight in kernel space
+                if let Some(spi_cmd) = maybe_spi_cmd {
+                    handler_mode = match self.process_spi_cmd(app_data, spi_cmd) {
+                        Ok(mode) => mode,
+                        Err(_) => HandlerMode::UserSpace,
+                    }
+                }
+
+                if handler_mode == HandlerMode::UserSpace {
+                    app_data.data_received_callback.map(
+                        |mut cb| cb.schedule(rx_len, usize::from(is_busy), 0));
+                }
             });
         });
     }
@@ -123,9 +190,20 @@ impl<'a> Driver for SpiDeviceSyscall<'a> {
         //debug!("subscribe: num={}, callback={}",
         //    subscribe_num, if callback.is_some() { "Some" } else { "None" });
         match subscribe_num {
-            0 => { // Data received
+            0 /* Data received
+                 Callback arguments:
+                 arg1: number of received bytes
+                 arg2: whether BUSY bit is set (0: false, otherwise: true) */ => {
                 self.apps.enter(app_id, |app_data, _| {
                     app_data.data_received_callback = callback;
+                    ReturnCode::SUCCESS
+                }).unwrap_or(ReturnCode::ENOMEM)
+            },
+            1 /* Address mode changed
+                 Callback arguments:
+                 arg1: new AddressMode as usize */ => {
+                self.apps.enter(app_id, |app_data, _| {
+                    app_data.address_mode_changed_callback = callback;
                     ReturnCode::SUCCESS
                 }).unwrap_or(ReturnCode::ENOMEM)
             },
@@ -148,15 +226,25 @@ impl<'a> Driver for SpiDeviceSyscall<'a> {
                 self.clear_busy(caller_id)
             },
             3 /* Set address mode
-                 arg1: 0 = 3 byte address mode, 1 = 4 byte address mode */ => {
+                 arg1: AddressMode as usize */ => {
                 let address_mode = match AddressMode::try_from(arg1) {
                     Ok(val) => val,
                     Err(_) => return ReturnCode::EINVAL
                 };
                 self.set_address_mode(caller_id, address_mode)
             },
-            4 /* Get address mode */ => {
+            4 /* Get address mode
+                 returns: AddressMode as usize */ => {
                 self.get_address_mode(caller_id)
+            }
+            5 /* Configure address mode handling
+                 (OpCode::Enter4ByteAddressMode and OpCode::Exit4ByteAddressMode)
+                 arg1: HandlerMode as usize */ => {
+                let handler_mode = match HandlerMode::try_from(arg1) {
+                    Ok(val) => val,
+                    Err(_) => return ReturnCode::EINVAL
+                };
+                self.set_address_mode_handling(caller_id, handler_mode)
             }
             _ => ReturnCode::ENOSUPPORT
         }

--- a/shared-lib/spiutils/src/driver.rs
+++ b/shared-lib/spiutils/src/driver.rs
@@ -1,0 +1,53 @@
+// Copyright 2020 lowRISC contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Kernel interface
+
+use core::convert::TryFrom;
+use core::default::Default;
+
+/// Handler mode.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+pub enum HandlerMode {
+    /// Do not handle request.
+    Disabled = 0,
+
+    /// Handle request in user space.
+    UserSpace = 1,
+
+    /// Handle request in kernel space.
+    KernelSpace = 2,
+}
+
+impl Default for HandlerMode {
+    fn default() -> Self { Self::Disabled }
+}
+
+/// Error for invalid handler mode conversion.
+pub struct InvalidHandlerMode;
+
+impl TryFrom<usize> for HandlerMode {
+    type Error = InvalidHandlerMode;
+
+    fn try_from(item: usize) -> Result<HandlerMode, Self::Error> {
+        match item {
+            0 => Ok(HandlerMode::Disabled),
+            1 => Ok(HandlerMode::UserSpace),
+            2 => Ok(HandlerMode::KernelSpace),
+            _ => Err(InvalidHandlerMode),
+        }
+    }
+}

--- a/shared-lib/spiutils/src/lib.rs
+++ b/shared-lib/spiutils/src/lib.rs
@@ -20,7 +20,9 @@
 
 //! Utilities for SPI
 
-#[macro_use]
-pub mod protocol;
+pub mod driver;
 
 pub mod io;
+
+#[macro_use]
+pub mod protocol;

--- a/shared-lib/spiutils/src/protocol/flash.rs
+++ b/shared-lib/spiutils/src/protocol/flash.rs
@@ -53,6 +53,12 @@ impl TryFrom<usize> for AddressMode {
     }
 }
 
+impl From<AddressMode> for usize {
+    fn from(item: AddressMode) -> usize {
+        item as usize
+    }
+}
+
 wire_enum! {
     /// SPI flash op codes
     pub enum OpCode: u8 {
@@ -146,7 +152,7 @@ wire_enum! {
     }
 }
 
-impl OpCode {
+impl<'a> OpCode {
     /// Returns true iff the OpCode requires an address.
     pub fn has_address(&self) -> bool {
         match self {


### PR DESCRIPTION
Note that this is built on-top of https://github.com/google/tock-on-titan/pull/180.

```
----------------------
`make prtest` summary:
----------------------
git rev-parse HEAD
0e772ea1f9ad42849ebb9bca136524271e51f830
git status
On branch addrmode-change-in-kernel
Your branch is up to date with 'origin/addrmode-change-in-kernel'.

nothing to commit, working tree clean
```
