### PR TITLE
Add support for H1's SpiHost to otpilot userspace app

### DIFF
--- a/userspace/otpilot/src/main.rs
+++ b/userspace/otpilot/src/main.rs
@@ -17,6 +17,7 @@
 #![no_std]
 
 mod spi_host;
+mod spi_host_h1;
 mod spi_device;
 
 use core::convert::TryFrom;
@@ -278,6 +279,9 @@ fn run() -> TockResult<()> {
 
     //////////////////////////////////////////////////////////////////////////////
 
+    // We cannot use the SPI host if passthrough is enabled.
+    spi_host_h1::get().disable_passthrough()?;
+
     let host_demo = SpiHostDemo {};
 
     writeln!(console, "Host: Enabling 4B mode")?;
@@ -327,6 +331,9 @@ fn run() -> TockResult<()> {
     spi_device::get().set_address_mode_handling(HandlerMode::KernelSpace)?;
 
     //////////////////////////////////////////////////////////////////////////////
+
+    // We need SPI passthrough to be fully operational.
+    spi_host_h1::get().enable_passthrough()?;
 
     loop {
         writeln!(console, "Device: Waiting for transaction")?;

--- a/userspace/otpilot/src/spi_host_h1.rs
+++ b/userspace/otpilot/src/spi_host_h1.rs
@@ -1,0 +1,80 @@
+// Copyright 2020 lowRISC contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use libtock::result::TockResult;
+use libtock::syscalls;
+
+pub trait SpiHostH1 {
+    /// Enable SPI passthrough.
+    fn enable_passthrough(&self) -> TockResult<()>;
+
+    /// Disable SPI passthrough.
+    fn disable_passthrough(&self) -> TockResult<()>;
+}
+
+// Get the static SpiHostH1 object.
+pub fn get() -> &'static dyn SpiHostH1 {
+    get_impl()
+}
+
+const DRIVER_NUMBER: usize = 0x40020;
+
+mod command_nr {
+    pub const CHECK_IF_PRESENT: usize = 0;
+    pub const ENABLE_DISABLE_PASSTHROUGH: usize = 1;
+}
+
+struct SpiHostH1Impl {}
+
+static mut SPI_HOST_H1: SpiHostH1Impl = SpiHostH1Impl {};
+
+static mut IS_INITIALIZED: bool = false;
+
+fn get_impl() -> &'static SpiHostH1Impl {
+    unsafe {
+        if !IS_INITIALIZED {
+            if SPI_HOST_H1.initialize().is_err() {
+                panic!("Could not initialize SPI Host H1");
+            }
+            IS_INITIALIZED = true;
+        }
+        &SPI_HOST_H1
+    }
+}
+
+impl SpiHostH1Impl {
+    fn initialize(&'static mut self) -> TockResult<()> {
+        syscalls::command(DRIVER_NUMBER, command_nr::CHECK_IF_PRESENT, 0, 0)?;
+
+        Ok(())
+    }
+
+    fn enable_disable_passtrough(&self, enable: bool) -> TockResult<()> {
+        syscalls::command(DRIVER_NUMBER, command_nr::ENABLE_DISABLE_PASSTHROUGH, if enable { 1 } else { 0 }, 0)?;
+
+        Ok(())
+    }
+}
+
+impl SpiHostH1 for SpiHostH1Impl {
+    fn enable_passthrough(&self) -> TockResult<()> {
+        self.enable_disable_passtrough(true)
+    }
+
+    fn disable_passthrough(&self) -> TockResult<()> {
+        self.enable_disable_passtrough(false)
+    }
+}


### PR DESCRIPTION
```
----------------------
`make prtest` summary:
----------------------
git rev-parse HEAD
96d9221461488a7e1632673a9fde7952650f0995
git status
On branch h1-spi-host-otpilot
Your branch is up to date with 'origin/h1-spi-host-otpilot'.

nothing to commit, working tree clean
```
