### PR TITLE
Add error handling to OTPilot

### DIFF
--- a/userspace/otpilot/src/main.rs
+++ b/userspace/otpilot/src/main.rs
@@ -283,8 +283,8 @@ impl<'a> SpiProcessor<'a> {
         let mut tx_cursor = SpiutilsCursor::new(&mut buf);
         header.to_wire(&mut tx_cursor)?;
         if header.get_opcode().has_dummy_byte() {
-            // Skip dummy byte
-            tx_cursor.write_bytes(&[1; 0])
+            // Skip one dummy byte (send 0x0)
+            tx_cursor.write_bytes(&[0x0; 1])
                 .map_err(|err| SpiProcessorError::ToWire(ToWireError::Io(err)))?;
         }
 

--- a/userspace/otpilot/src/spi_device.rs
+++ b/userspace/otpilot/src/spi_device.rs
@@ -16,9 +16,7 @@
 
 use core::cell::Cell;
 use core::convert::TryFrom;
-use core::fmt::Write;
 
-use libtock::console::Console;
 use libtock::result::TockError;
 use libtock::result::TockResult;
 use libtock::shared_memory::SharedMemory;
@@ -194,9 +192,6 @@ impl SpiDeviceImpl {
             Ok(val) => self.address_mode.set(val),
             Err(_) => ()
         }
-
-        let mut console = Console::new();
-        writeln!(console, "address_mode_changed: {:?}", arg1);
     }
 }
 


### PR DESCRIPTION
This PR builds on top of https://github.com/google/tock-on-titan/pull/183.

```
----------------------
`make prtest` summary:
----------------------
git rev-parse HEAD
5199c0083d9eb1df1820a40a308279dee415f74d
git status
On branch otpilot-error-handling
Your branch is up to date with 'origin/otpilot-error-handling'.

nothing to commit, working tree clean
```
