### PR TITLE
SPI device on Papa board starts up in 3-byte address mode.

### DIFF
--- a/kernel/papa/src/main.rs
+++ b/kernel/papa/src/main.rs
@@ -312,7 +312,7 @@ pub unsafe fn reset_handler() {
     h1::spi_device::SPI_DEVICE0.init(h1::spi_device::SpiDeviceConfiguration {
         enable_fastread4b_cmd: false,
         enable_enterexit4b_cmd: true,
-        startup_address_mode: spiutils::protocol::flash::AddressMode::FourByte,
+        startup_address_mode: spiutils::protocol::flash::AddressMode::ThreeByte,
     });
     let h1_spi_device_syscalls = static_init!(
         h1_syscalls::spi_device::SpiDeviceSyscall<'static>,


### PR DESCRIPTION
"make build localtests"  did run to completion with exit status zero.