### PR TITLE
Add some detail to Readme.md; Don't fail build when one of TANGO_CODESIGNER{,_KEY} is not set.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,38 @@ This repository contains ports of Tock OS (https://www.tockos.org) to Titan
 chips.
 
 This is not an officially supported Google product.
+
+
+## Getting started
+
+### Clone the repo
+
+Get the source:
+
+```shell
+git clone --recursive https://github.com/google/tock-on-titan.git
+```
+
+### Get the tools and libs to build the code
+
+Download Rust
+
+```shell
+cd tock-on-titan
+curl https://sh.rustup.rs -sSf | sh
+```
+
+Configure Rust
+
+```shell
+make setup
+```
+
+### Build all boards and apps
+
+```shell
+make
+```
+
+Note that if one of TANGO_CODESIGNER{,_KEY} is not set, then signed artifacts
+will not be created.

--- a/userspace/Build.mk
+++ b/userspace/Build.mk
@@ -130,11 +130,16 @@ build/userspace/$(APP)/$(BOARD)/full_image: \
 	arm-none-eabi-objcopy --update-section \
 		.apps=build/userspace/$(APP)/cortex-m3/cortex-m3.tbf \
 		build/userspace/$(APP)/$(BOARD)/unsigned_image
-	$(TANGO_CODESIGNER) --b --input build/userspace/$(APP)/$(BOARD)/unsigned_image \
-		--key=$(TANGO_CODESIGNER_KEY) \
-		--output=build/userspace/$(APP)/$(BOARD)/signed_image
-	cat $(TANGO_BOOTLOADER) build/userspace/$(APP)/$(BOARD)/signed_image \
-		> build/userspace/$(APP)/$(BOARD)/full_image
+	if [ -n "${TANGO_CODESIGNER}" -a -n "${TANGO_CODESIGNER_KEY}" ]; then \
+		$(TANGO_CODESIGNER) --b --input build/userspace/$(APP)/$(BOARD)/unsigned_image \
+			--key=$(TANGO_CODESIGNER_KEY) \
+			--output=build/userspace/$(APP)/$(BOARD)/signed_image; \
+		cat $(TANGO_BOOTLOADER) build/userspace/$(APP)/$(BOARD)/signed_image \
+			> build/userspace/$(APP)/$(BOARD)/full_image; \
+	else \
+		echo "***** Can't create signed_image -- one of CODESIGNER{,_KEY} is empty "; \
+		echo "*****   -- hope that's OK."; \
+	fi
 
 endef
 
@@ -283,11 +288,16 @@ build/userspace/$(APP)/$(BOARD)/full_image: \
 	arm-none-eabi-objcopy --update-section \
 		.apps=build/userspace/$(APP)/$(BOARD)/app.tbf \
 		build/userspace/$(APP)/$(BOARD)/unsigned_image
-	$(TANGO_CODESIGNER) --b --input build/userspace/$(APP)/$(BOARD)/unsigned_image \
-		--key=$(TANGO_CODESIGNER_KEY) \
-		--output=build/userspace/$(APP)/$(BOARD)/signed_image
-	cat $(TANGO_BOOTLOADER) build/userspace/$(APP)/$(BOARD)/signed_image \
-		> build/userspace/$(APP)/$(BOARD)/full_image
+	if [ -n "${TANGO_CODESIGNER}" -a -n "${TANGO_CODESIGNER_KEY}" ]; then \
+		$(TANGO_CODESIGNER) --b --input build/userspace/$(APP)/$(BOARD)/unsigned_image \
+			--key=$(TANGO_CODESIGNER_KEY) \
+			--output=build/userspace/$(APP)/$(BOARD)/signed_image; \
+		cat $(TANGO_BOOTLOADER) build/userspace/$(APP)/$(BOARD)/signed_image \
+			> build/userspace/$(APP)/$(BOARD)/full_image; \
+	else \
+		echo "***** Can't create signed_image -- one of CODESIGNER{,_KEY} is empty "; \
+		echo "*****   -- hope that's OK."; \
+	fi
 
 endef
 
@@ -428,11 +438,16 @@ build/userspace/$(APP)/$(BOARD)/full_image: \
 	arm-none-eabi-objcopy --update-section \
 		.apps=build/userspace/$(APP)/$(BOARD)/app.tbf \
 		build/userspace/$(APP)/$(BOARD)/unsigned_image
-	$(TANGO_CODESIGNER) --b --input build/userspace/$(APP)/$(BOARD)/unsigned_image \
-		--key=$(TANGO_CODESIGNER_KEY) \
-		--output=build/userspace/$(APP)/$(BOARD)/signed_image
-	cat $(TANGO_BOOTLOADER) build/userspace/$(APP)/$(BOARD)/signed_image \
-		> build/userspace/$(APP)/$(BOARD)/full_image
+	if [ -n "${TANGO_CODESIGNER}" -a -n "${TANGO_CODESIGNER_KEY}" ]; then \
+		$(TANGO_CODESIGNER) --b --input build/userspace/$(APP)/$(BOARD)/unsigned_image \
+			--key=$(TANGO_CODESIGNER_KEY) \
+			--output=build/userspace/$(APP)/$(BOARD)/signed_image; \
+		cat $(TANGO_BOOTLOADER) build/userspace/$(APP)/$(BOARD)/signed_image \
+			> build/userspace/$(APP)/$(BOARD)/full_image; \
+	else \
+		echo "***** Can't create signed_image -- one of CODESIGNER{,_KEY} is empty "; \
+		echo "*****   -- hope that's OK."; \
+	fi
 
 endef
 


### PR DESCRIPTION
**Remember to run `make prtest` and paste the output here (replace this line)**

Well, not sure that the Makefile change is a good idea -- see commit comment.

`make prtest` doesn't pass, regardless of whether `TANGO_CODESIGNER{,_KEY}` are set, but it fails differently (and earlier, I think) when they're not set.  Which reinforces my nervousness about the change.