### PR TITLE
Revert "userspace/Build.mk: factor FULL_IMAGE_TARGET."

### DIFF
--- a/userspace/Build.mk
+++ b/userspace/Build.mk
@@ -80,41 +80,6 @@ include $(addsuffix /Build.mk,$(BUILD_SUBDIRS))
 #   userspace/app2/build: build/userspace/app2/board2/full_image
 #   userspace/app3/build: build/userspace/app3/board2/full_image
 
-
-# ------------------------------------------------------------------------------
-# Macro to define a full_image target for a specific
-# board-and-app-and-tbf-file combination.
-# Arguments:
-# - $(BOARD)
-# - $(APP)
-# - $(TBF_FILE)
-define FULL_IMAGE_TARGET
-
-build/userspace/$(APP)/$(BOARD)/full_image: \
-		build/userspace/$(APP)/$(TBF_FILE) \
-		kernel/build
-	mkdir -p build/userspace/$(APP)/$(BOARD)/
-	cp build/kernel/cargo/thumbv7m-none-eabi/release/$(BOARD) \
-		build/userspace/$(APP)/$(BOARD)/unsigned_image
-	arm-none-eabi-objcopy --set-section-flags .apps=alloc,code,contents \
-		build/userspace/$(APP)/$(BOARD)/unsigned_image
-	arm-none-eabi-objcopy --update-section \
-		.apps=build/userspace/$(APP)/$(TBF_FILE) \
-		build/userspace/$(APP)/$(BOARD)/unsigned_image
-	if [ -n "${TANGO_CODESIGNER}" -a -n "${TANGO_CODESIGNER_KEY}" ]; then \
-		$(TANGO_CODESIGNER) --b --input build/userspace/$(APP)/$(BOARD)/unsigned_image \
-			--key=$(TANGO_CODESIGNER_KEY) \
-			--output=build/userspace/$(APP)/$(BOARD)/signed_image; \
-		cat $(TANGO_BOOTLOADER) build/userspace/$(APP)/$(BOARD)/signed_image \
-			> build/userspace/$(APP)/$(BOARD)/full_image; \
-	else \
-		echo "***** Can't create signed_image -- one of CODESIGNER{,_KEY} is empty "; \
-		echo "*****   -- hope that's OK."; \
-	fi
-
-endef
-
-
 # ------------------------------------------------------------------------------
 # Macro to define targets for a specific board-and-app combination.
 # Arguments:
@@ -154,8 +119,27 @@ userspace/$(APP)/$(BOARD)/run: \
 		stty -F /dev/ttyUltraTarget2 115200 -icrnl ; \
 		build/cargo-host/release/runner'
 
-TBF_FILE := cortex-m3/cortex-m3.tbf
-$(eval $(FULL_IMAGE_TARGET))
+build/userspace/$(APP)/$(BOARD)/full_image: \
+		build/userspace/$(APP)/cortex-m3/cortex-m3.tbf \
+		kernel/build
+	mkdir -p build/userspace/$(APP)/$(BOARD)/
+	cp build/kernel/cargo/thumbv7m-none-eabi/release/$(BOARD) \
+		build/userspace/$(APP)/$(BOARD)/unsigned_image
+	arm-none-eabi-objcopy --set-section-flags .apps=alloc,code,contents \
+		build/userspace/$(APP)/$(BOARD)/unsigned_image
+	arm-none-eabi-objcopy --update-section \
+		.apps=build/userspace/$(APP)/cortex-m3/cortex-m3.tbf \
+		build/userspace/$(APP)/$(BOARD)/unsigned_image
+	if [ -n "${TANGO_CODESIGNER}" -a -n "${TANGO_CODESIGNER_KEY}" ]; then \
+		$(TANGO_CODESIGNER) --b --input build/userspace/$(APP)/$(BOARD)/unsigned_image \
+			--key=$(TANGO_CODESIGNER_KEY) \
+			--output=build/userspace/$(APP)/$(BOARD)/signed_image; \
+		cat $(TANGO_BOOTLOADER) build/userspace/$(APP)/$(BOARD)/signed_image \
+			> build/userspace/$(APP)/$(BOARD)/full_image; \
+	else \
+		echo "***** Can't create signed_image -- one of CODESIGNER{,_KEY} is empty "; \
+		echo "*****   -- hope that's OK."; \
+	fi
 
 endef
 
@@ -293,8 +277,27 @@ build/userspace/$(APP)/$(BOARD)/app.tbf: \
 		     false ; \
 		fi
 
-TBF_FILE := $(BOARD)/app.tbf
-$(eval $(FULL_IMAGE_TARGET))
+build/userspace/$(APP)/$(BOARD)/full_image: \
+		build/userspace/$(APP)/$(BOARD)/app.tbf \
+		kernel/build
+	mkdir -p build/userspace/$(APP)/$(BOARD)/
+	cp build/kernel/cargo/thumbv7m-none-eabi/release/$(BOARD) \
+		build/userspace/$(APP)/$(BOARD)/unsigned_image
+	arm-none-eabi-objcopy --set-section-flags .apps=alloc,code,contents \
+		build/userspace/$(APP)/$(BOARD)/unsigned_image
+	arm-none-eabi-objcopy --update-section \
+		.apps=build/userspace/$(APP)/$(BOARD)/app.tbf \
+		build/userspace/$(APP)/$(BOARD)/unsigned_image
+	if [ -n "${TANGO_CODESIGNER}" -a -n "${TANGO_CODESIGNER_KEY}" ]; then \
+		$(TANGO_CODESIGNER) --b --input build/userspace/$(APP)/$(BOARD)/unsigned_image \
+			--key=$(TANGO_CODESIGNER_KEY) \
+			--output=build/userspace/$(APP)/$(BOARD)/signed_image; \
+		cat $(TANGO_BOOTLOADER) build/userspace/$(APP)/$(BOARD)/signed_image \
+			> build/userspace/$(APP)/$(BOARD)/full_image; \
+	else \
+		echo "***** Can't create signed_image -- one of CODESIGNER{,_KEY} is empty "; \
+		echo "*****   -- hope that's OK."; \
+	fi
 
 endef
 
@@ -424,8 +427,27 @@ build/userspace/$(APP)/$(BOARD)/app.tbf: \
 		     false ; \
 		fi
 
-TBF_FILE := $(BOARD)/app.tbf
-$(eval $(FULL_IMAGE_TARGET))
+build/userspace/$(APP)/$(BOARD)/full_image: \
+		build/userspace/$(APP)/$(BOARD)/app.tbf \
+		kernel/build
+	mkdir -p build/userspace/$(APP)/$(BOARD)/
+	cp build/kernel/cargo/thumbv7m-none-eabi/release/$(BOARD) \
+		build/userspace/$(APP)/$(BOARD)/unsigned_image
+	arm-none-eabi-objcopy --set-section-flags .apps=alloc,code,contents \
+		build/userspace/$(APP)/$(BOARD)/unsigned_image
+	arm-none-eabi-objcopy --update-section \
+		.apps=build/userspace/$(APP)/$(BOARD)/app.tbf \
+		build/userspace/$(APP)/$(BOARD)/unsigned_image
+	if [ -n "${TANGO_CODESIGNER}" -a -n "${TANGO_CODESIGNER_KEY}" ]; then \
+		$(TANGO_CODESIGNER) --b --input build/userspace/$(APP)/$(BOARD)/unsigned_image \
+			--key=$(TANGO_CODESIGNER_KEY) \
+			--output=build/userspace/$(APP)/$(BOARD)/signed_image; \
+		cat $(TANGO_BOOTLOADER) build/userspace/$(APP)/$(BOARD)/signed_image \
+			> build/userspace/$(APP)/$(BOARD)/full_image; \
+	else \
+		echo "***** Can't create signed_image -- one of CODESIGNER{,_KEY} is empty "; \
+		echo "*****   -- hope that's OK."; \
+	fi
 
 endef
 


### PR DESCRIPTION
This reverts commit c8fcd54a7c38b5998061ed5a791476e228d41c5d.

It looks like the make variable TBF_FILE is not set in a place that I
think it must be.

I thought I tested pretty thoroughly yesterday -- no idea how this
problem (which seems like not a corner case at all) made it through my
testing, or through the automated tests that are run.

But we need to have mainline working, so I need to revert before doing
anything further.

Signed-off-by: Dan Nussbaum <dansn@google.com>

**Remember to run `make prtest` and paste the output here (replace this line)**
