### PR TITLE
Split `build-signed` target out from `build` target.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,15 +41,15 @@ jobs:
       - name: Make setup
         run: make -C "${GITHUB_WORKSPACE}" setup
 
-      # Install the bubblewrap sandboxing tool.
-      - name: Install Bubblewrap
-        run: sudo apt-get install bubblewrap
+      # Install packages our build system depends on.
+      - name: Install Packages
+        run: sudo apt-get install bubblewrap gcc-arm-none-eabi
 
-      # Runs the `check` and `localtests` make actions. We cannot build this
-      # repository in GitHub Actions as building requires non-publicly-available
-      # code signing tools, so this is the best we can do (at least for now --
-      # theoretically we could build up until the code signing step but the
-      # makefiles are not structured for that yet). I use -j2 because the VMs
-      # that GitHub Actions uses have 2 logical CPUs.
-      - name: Check and local tests
-        run: make -C "${GITHUB_WORKSPACE}" -j2 check localtests
+      # Runs the `build`, `check` and `localtests` make actions.  We
+      # cannot build the `build-signed` target as doing so requires
+      # non-publicly-available code signing tools, so this is the best
+      # we can do (at least for now).
+      # We use -j2 because the VMs that GitHub Actions uses have 2
+      # logical CPUs.
+      - name: Build, check and local tests
+        run: make -C "${GITHUB_WORKSPACE}" -j2 build check localtests

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Note that `all` does _not_ depend on `build-signed`.  Many consumers
+# of this project (especially new ones) won't be happy if they have to
+# struggle with signing from day one.
 .PHONY: all
 all: build
 
@@ -54,6 +57,9 @@ sandbox_setup:
 
 .PHONY: build
 build: $(addsuffix /build,$(BUILD_SUBDIRS))
+
+.PHONY: build-signed
+build-signed: $(addsuffix /build-signed,$(BUILD_SUBDIRS))
 
 .PHONY: check
 check: $(addsuffix /check,$(BUILD_SUBDIRS))

--- a/README.md
+++ b/README.md
@@ -31,11 +31,17 @@ Configure Rust
 make setup
 ```
 
-### Build all boards and apps
+### Build all boards and apps (unsigned)
 
 ```shell
-make
+make build
 ```
 
-Note that if one of TANGO_CODESIGNER{,_KEY} is not set, then signed artifacts
-will not be created.
+### Build 'signed' versions of all artifacts
+
+```shell
+make build-signed
+```
+
+The `build-signed` target requires `TANGO_CODESIGNER` and `TANGO_CODESIGNER_KEY`
+to be set. The codesigner and keys are not publicly available.

--- a/doc/build_system.md
+++ b/doc/build_system.md
@@ -16,6 +16,7 @@ for instance, `userspace/h1_tests/Build.mk` should implement the following
 actions:
 
 * `userspace/h1_tests/build`
+* `userspace/h1_tests/build-signed`
 * `userspace/h1_tests/check`
 * `userspace/h1_tests/devicetests`
 * `userspace/h1_tests/doc`
@@ -38,6 +39,7 @@ exceptions to this (documented below).
 Each Build.mk should support the following targets:
 
 * `$PATH/build`
+* `$PATH/build-signed`
 * `$PATH/check`
 * `$PATH/devicetests`
 * `$PATH/doc`

--- a/doc/make_targets.md
+++ b/doc/make_targets.md
@@ -6,7 +6,7 @@ Common Makefile Targets
 For consistency, we want to expose the same `make` targets in each Makefile. For
 simplicity of development and testing, we want `make` commands run at the root
 of the repository to operate throughout the project. For example, running `make
-build` in `tock-on-titan/` should build all targets in the repository.
+build` in `tock-on-titan/` should build all unsigned targets in the repository.
 
 This specification defines common target names for the `tock-on-titan`
 repository. It is meant to be a reference for users of the build system (e.g.
@@ -26,10 +26,11 @@ Unless otherwise noted, the following targets operate in the directory in which
 <action> ...`. All per-directory makefiles support these targets, even if they
 do nothing (e.g. `make devicetests` in a directory with no device tests is a
 no-op but will succeed):
-
 * `all` is an alias for `build` (following Makefile tradition).
-* `build` compiles the code. This can be a library, an application image, the
-  kernel image, or the full flash image (kernel + applications).
+* `build` compiles the code, yielding unsigned artifacts. This can be a library,
+  an application image, the kernel image, or the full flash image (kernel +
+  applications).
+* `build-signed` compiles the code (via `build`), and then signs all artifacts.
 * `check` runs `cargo check`-style tests.
 * `clean` removes all build artifacts we know how to remove. It applies to the
   repository, not just the subdirectory it is called in.

--- a/kernel/Build.mk
+++ b/kernel/Build.mk
@@ -16,6 +16,9 @@
 kernel/build: sandbox_setup
 	cd kernel && $(BWRAP) cargo build --release
 
+.PHONY: kernel/build-signed
+kernel/build-signed: kernel/build
+
 .PHONY: kernel/check
 kernel/check: sandbox_setup
 	cd kernel && $(BWRAP) cargo check --release

--- a/runner/Build.mk
+++ b/runner/Build.mk
@@ -15,12 +15,15 @@
 .PHONY: runner/build
 runner/build: build/cargo-host/release/runner
 
+.PHONY: runner/build-signed
+runner/build-signed: runner/build
+
 .PHONY: runner/check
 runner/check: sandbox_setup
 	cd runner && \
 		CARGO_TARGET_DIR="../build/cargo-host" $(BWRAP) cargo check
 
-.PHONY: kernel/clean
+.PHONY: runner/clean
 runner/clean:
 	rm -f runner/Cargo.lock
 

--- a/third_party/Build.mk
+++ b/third_party/Build.mk
@@ -26,6 +26,9 @@ third_party/build: build/cargo-host/release/elf2tab sandbox_setup
 		CARGO_TARGET_DIR="../../build/userspace/cargo" \
 		$(BWRAP) cargo build --offline --release --target=thumbv7m-none-eabi --examples
 
+.PHONY: third_party/build-signed
+third_party/build-signed: third_party/build
+
 .PHONY: third_party/check
 third_party/check: cargo_version_check sandbox_setup
 	cd third_party/elf2tab && \

--- a/tools/Build.mk
+++ b/tools/Build.mk
@@ -16,6 +16,9 @@
 tools/build: cargo_version_check sandbox_setup
 	cd tools && $(BWRAP) cargo build --offline --release
 
+.PHONY: tools/build-signed
+tools/build-signed: tools/build
+
 .PHONY: tools/check
 tools/check: cargo_version_check sandbox_setup
 	cd tools && $(BWRAP) cargo check --offline --release


### PR DESCRIPTION
Add `build-signed` target to <sandbox-root>/Makefile.

Add `build-signed` targets to all $(SUBDIR)/Build.mk for all subdirs
of <sandbox-root>.  All associated changes are trivial save for that
in userspace/Build.mk.

Update docs to explain the `build`/`build-signed` bifurcation.

Signed-off-by: Dan Nussbaum <dansn@google.com>

**Remember to run `make prtest` and paste the output here (replace this line)**
