### PR TITLE
third_party/Build.mk: sandbox elf2tab build by copying source

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,6 @@ BUILD_SUBDIRS := kernel runner third_party tools userspace
 BWRAP := bwrap                                                               \
          --ro-bind / /                                                       \
          --bind "$(CURDIR)/build" "$(CURDIR)/build"                          \
-         --bind "$(CURDIR)/build/Cargo.lock/elf2tab"                         \
-                "$(CURDIR)/third_party/elf2tab/Cargo.lock"                   \
          --bind "$(CURDIR)/kernel/Cargo.lock" "$(CURDIR)/kernel/Cargo.lock"  \
          --bind "$(CURDIR)/runner/Cargo.lock" "$(CURDIR)/runner/Cargo.lock"  \
          --bind "$(CURDIR)/third_party/libtock-rs/Cargo.lock"                \
@@ -46,8 +44,7 @@ BWRAP := bwrap                                                               \
 # A target that sets up directories the bwrap sandbox needs.
 .PHONY: sandbox_setup
 sandbox_setup:
-	mkdir -p build/Cargo.lock
-	>build/Cargo.lock/elf2tab
+	mkdir -p build
 	>kernel/Cargo.lock
 	>runner/Cargo.lock
 	>third_party/libtock-rs/Cargo.lock

--- a/third_party/Build.mk
+++ b/third_party/Build.mk
@@ -30,8 +30,8 @@ third_party/build: build/cargo-host/release/elf2tab sandbox_setup
 third_party/build-signed: third_party/build
 
 .PHONY: third_party/check
-third_party/check: cargo_version_check sandbox_setup
-	cd third_party/elf2tab && \
+third_party/check: cargo_version_check sandbox_setup build/elf2tab
+	cd build/elf2tab && \
 		CARGO_TARGET_DIR="../../build/cargo-host" $(BWRAP) cargo check --release
 	cd third_party/libtock-rs && \
 		CARGO_TARGET_DIR="../../build/userspace/cargo" \
@@ -49,16 +49,16 @@ third_party/clean:
 third_party/devicetests:
 
 .PHONY: third_party/doc
-third_party/doc: cargo_version_check sandbox_setup
-	cd third_party/elf2tab && \
+third_party/doc: cargo_version_check sandbox_setup build/elf2tab
+	cd build/elf2tab && \
 		CARGO_TARGET_DIR="../../build/cargo-host" $(BWRAP) cargo doc --release
 	cd third_party/rustc-demangle && \
 		CARGO_TARGET_DIR="../../build/cargo-host" \
 		$(BWRAP) cargo doc --offline --release
 
 .PHONY: third_party/localtests
-third_party/localtests: cargo_version_check sandbox_setup
-	cd third_party/elf2tab && \
+third_party/localtests: cargo_version_check sandbox_setup build/elf2tab
+	cd build/elf2tab && \
 		CARGO_TARGET_DIR="../../build/cargo-host" $(BWRAP) cargo test --release
 	cd third_party/libtock-rs && \
 		CARGO_TARGET_DIR="../../build/cargo-host" \
@@ -69,6 +69,12 @@ third_party/localtests: cargo_version_check sandbox_setup
 
 
 .PHONY: build/cargo-host/release/elf2tab
-build/cargo-host/release/elf2tab: cargo_version_check sandbox_setup
-	cd third_party/elf2tab && \
+build/cargo-host/release/elf2tab: cargo_version_check build/elf2tab
+	cd build/elf2tab && \
 		CARGO_TARGET_DIR="../../build/cargo-host" $(BWRAP) cargo build --release
+
+.PHONY: build/elf2tab
+build/elf2tab:
+	rm -rf build/elf2tab && \
+	cp -rp -t build third_party/elf2tab && \
+	rm -f build/elf2tab/Cargo.lock


### PR DESCRIPTION
The bubblewrap workaround for elf2tab's checked-in Cargo.lock file
messing up offline builds does not work in a docker container.  So a
more straightforward workaround is to simply copy the source tree for
elf2tab out of third_party/ and into build/ where we can simply remove
the Cargo.lock file before calling cargo build.  With this change, it
should be possible to build in a suitable docker container (that
contains the necessary tool chains) by invoking 'make BWRAP='.

"make build localtests" did run to completion with exit status zero.