### PR TITLE
Add new build-signed target to DirShim.mk

### DIFF
--- a/DirShim.mk
+++ b/DirShim.mk
@@ -29,6 +29,10 @@ all: build
 build:
 	$(MAKE) -C $(TOCK_ON_TITAN) $(INVOKE_DIR)/build
 
+.PHONY: build-signed
+build-signed:
+	$(MAKE) -C $(TOCK_ON_TITAN) $(INVOKE_DIR)/build-signed
+
 .PHONY: check
 check:
 	$(MAKE) -C $(TOCK_ON_TITAN) $(INVOKE_DIR)/check


### PR DESCRIPTION
This change allows to specifially build the signed image for just a single directory.

Example:

```
make -C userspace/otpilot build-signed
```