### PR TITLE
Fix a race condition in building C apps.

### DIFF
--- a/doc/build_system.md
+++ b/doc/build_system.md
@@ -82,6 +82,8 @@ build/
                         # elf2tab's toolchain version.
     device_lock         # Lock file used with flock() to prevent concurrent uses
                         # of the device.
+    libtock_c_lock      # Lock file used with flock to prevent concurrent uses
+                        # of libtock-c's Makefiles.
     userspace/
         cargo/          # userspace/ Cargo workspace target tree. Uses
                         # libtock-rs's toolchain version.

--- a/userspace/Build.mk
+++ b/userspace/Build.mk
@@ -182,7 +182,7 @@ define C_APP_TARGETS
 .PHONY: build/userspace/$(APP)/cortex-m3/cortex-m3.tbf
 build/userspace/$(APP)/cortex-m3/cortex-m3.tbf: \
 		build/cargo-host/release/elf2tab
-	+$(BWRAP) $(MAKE) -C userspace/$(APP) -f TockMakefile
+	+flock build/libtock_c_lock $(BWRAP) $(MAKE) -C userspace/$(APP) -f TockMakefile
 
 endef
 


### PR DESCRIPTION
The libtock-c application makefiles are not designed to be invoked concurrently for different apps. Doing so can result in linking errors, where one app's build system is re-building libraries (such as libh1) while another app's build system is trying to link against the library.

It does not appear that libtock-c's makefiles are designed to build multiple apps at once, so instead I decided to use a mutex to build apps one-at-a-time. I used flock for this, the same tool I used to serialize devicetests.

I tested this with several `make -j <all C apps>` invocations on my machine.

```
----------------------
`make prtest` summary:
----------------------
git rev-parse HEAD
f212caecf93f255e2da97813f4ac8da9b9a2e0d4
git status
On branch race-fix
nothing to commit, working tree clean
```
