### PR TITLE
third_party/Build.mk: fix elf2tab build sandbox

### DIFF
--- a/third_party/Build.mk
+++ b/third_party/Build.mk
@@ -75,6 +75,7 @@ build/cargo-host/release/elf2tab: cargo_version_check build/elf2tab
 
 .PHONY: build/elf2tab
 build/elf2tab:
+	mkdir -p build && \
 	rm -rf build/elf2tab && \
 	cp -rp -t build third_party/elf2tab && \
 	rm -f build/elf2tab/Cargo.lock


### PR DESCRIPTION
e45fbb29 broke builds of specific targets if the whole tree had not
been built previously.  Add a mkdir -p build in case sandbox_setup
has not been done already.  This might be redundant, but that's what
the -p flag to mkdir is for.

"make build localtests" did run to completion with exit status zero.
