### PR TITLE
Fix the app size check: `$` needs to be escaped twice, not once.

### DIFF
--- a/userspace/Build.mk
+++ b/userspace/Build.mk
@@ -312,7 +312,7 @@ build/userspace/$(APP)/$(BOARD)/app.tbf: \
 		-o build/userspace/$(APP)/$(BOARD)/app_tab \
 		build/userspace/$(APP)/$(BOARD)/app --stack=2048 --app-heap=4096 \
 		--kernel-heap=1024 --protected-region-size=64
-	if [ "$$(wc -c <build/userspace/$(APP)/$(BOARD)/app.tbf)" -ge 65536 ]; \
+	if [ "$$$$(wc -c build/userspace/$(APP)/$(BOARD)/app.tbf)" -ge 65536 ]; \
 		then echo "#########################################################"; \
 		     echo "# Application $(notdir $(APP)) for board $(BOARD) is too large."; \
 		     echo "# Check size of build/userspace/$(APP)/$(BOARD)/app.tbf"; \
@@ -454,7 +454,7 @@ build/userspace/$(APP)/$(BOARD)/app.tbf: \
 		-o build/userspace/$(APP)/$(BOARD)/app_tab \
 		build/userspace/$(APP)/$(BOARD)/app --stack=2048 --app-heap=4096 \
 		--kernel-heap=1024 --protected-region-size=64
-	if [ "$$(wc -c <build/userspace/$(APP)/$(BOARD)/app.tbf)" -ge 65536 ]; \
+	if [ "$$$$(wc -c build/userspace/$(APP)/$(BOARD)/app.tbf)" -ge 65536 ]; \
 		then echo "#########################################################"; \
 		     echo "# Application $(APP) for board $(BOARD) is too large."; \
 		     echo "# Check size of build/userspace/$(APP)/$(BOARD)/app.tbf"; \


### PR DESCRIPTION
This was probably broken when we moved the app build rules into defines. I also removed `<` from the `wc` commands as it is unnecessary.

Thank you to @dann21 for bringing this up!

```
----------------------
`make prtest` summary:
----------------------
git rev-parse HEAD
0f0c985492214d8486e3e2309f0e0d944548df48
git status
On branch size-check-fix
Your branch is up to date with 'origin/size-check-fix'.

nothing to commit, working tree clean
```