### PR TITLE
otpilot: Fixed handling of errors during SPI processing.

### DIFF
--- a/userspace/otpilot/src/main.rs
+++ b/userspace/otpilot/src/main.rs
@@ -163,6 +163,8 @@ fn run() -> TockResult<()> {
                             // Ignore error from writeln. There's nothing we can do here anyway.
                             let _ = writeln!(console, "Device: Error ending transaction.");
                         }
+                    } else {
+                        spi_device::get().end_transaction();
                     }
                 }
             }

--- a/userspace/otpilot/src/spi_device.rs
+++ b/userspace/otpilot/src/spi_device.rs
@@ -43,6 +43,9 @@ pub trait SpiDevice {
     /// Whether the transaction has the WRITE ENABLE bit set.
     fn is_write_enable_set(&self) -> bool;
 
+    /// End the transaction without changing any status bits or returning data.
+    fn end_transaction(&self);
+
     /// End the transaction and clear the BUSY and/or the WRITE ENABLE bits.
     fn end_transaction_with_status(&self, clear_busy: bool, clear_write_enable: bool) -> TockResult<()>;
 
@@ -216,6 +219,10 @@ impl SpiDevice for SpiDeviceImpl {
 
     fn is_write_enable_set(&self) -> bool {
         self.is_write_enable_set.get()
+    }
+
+    fn end_transaction(&self) {
+        self.clear_transaction();
     }
 
     fn end_transaction_with_status(&self, clear_busy: bool, clear_write_enable: bool) -> TockResult<()> {


### PR DESCRIPTION
We were previously not clearing the buffer, which resulted in
the message being processed repeatedly.
