### PR TITLE
otpilot: Fix main loop to not use console before yieldk.

### DIFF
--- a/userspace/otpilot/src/main.rs
+++ b/userspace/otpilot/src/main.rs
@@ -147,7 +147,9 @@ fn run() -> TockResult<()> {
 
     loop {
         while !spi_device::get().have_transaction() {
-            let _ = writeln!(console, "yieldk()");
+
+            // Note: Do NOT use the console here, as that results in a "hidden"
+            // yieldk() which causes us to lose track of the conditions above.
             unsafe { yieldk(); }
         }
 


### PR DESCRIPTION
We used to print "yieldk()" to the console after checking conditions
but before actually calling yieldk() in the main loop. Since printing
to the console may result in calls to yieldk(), this resulted in the
main loop missing changed conditions and going into yieldk() again,
which could result in intermittent hangs.