### PR TITLE
otpilot: Make spi_processor less noisy

### DIFF
--- a/userspace/otpilot/src/main.rs
+++ b/userspace/otpilot/src/main.rs
@@ -96,6 +96,7 @@ fn run() -> TockResult<()> {
 
     let mut spi_processor = SpiProcessor {
         server: manticore_support::get_pa_rot(&identity),
+        print_flash_headers: false,  // Enable to print incoming SPI flash headers
     };
 
     //////////////////////////////////////////////////////////////////////////////

--- a/userspace/otpilot/src/spi_processor.rs
+++ b/userspace/otpilot/src/spi_processor.rs
@@ -88,7 +88,11 @@ impl From<core::fmt::Error> for SpiProcessorError {
 //////////////////////////////////////////////////////////////////////////////
 
 pub struct SpiProcessor<'a> {
+    // The Manticore protocol server.
     pub server: PaRot<'a, Identity, Reset, NoRsa>,
+
+    // Whether to print incoming flash headers.
+    pub print_flash_headers: bool,
 }
 
 const SPI_TX_BUF_SIZE : usize = 512;
@@ -278,12 +282,16 @@ impl<'a> SpiProcessor<'a> {
         match spi_device::get().get_address_mode() {
             AddressMode::ThreeByte => {
                 let header = flash::Header::<ux::u24>::from_wire(&mut rx_buf)?;
-                writeln!(console, "Device: flash header (3B): {:?}", header)?;
+                if self.print_flash_headers {
+                    writeln!(console, "Device: flash header (3B): {:?}", header)?;
+                }
                 self.process_spi_header(&header, rx_buf)
             }
             AddressMode::FourByte => {
                 let header = flash::Header::<u32>::from_wire(&mut rx_buf)?;
-                writeln!(console, "Device: flash header (4B): {:?}", header)?;
+                if self.print_flash_headers {
+                    writeln!(console, "Device: flash header (4B): {:?}", header)?;
+                }
                 self.process_spi_header(&header, rx_buf)
             }
         }


### PR DESCRIPTION
This change adds explicit handling for SPI command 0xC8 (read extended address register). It further adds an option for conditionally enabling the SpiProcessor to print the headers of incoming SPI packets, defaulting to "off" (it was previously always printing these headers, causing a lot of noise on the console).