### PR TITLE
Make builds under `/tmp` work.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,12 @@ BUILD_SUBDIRS := kernel runner third_party tools userspace
 # installing things during builds. We don't like that. This is a sandbox we can
 # run commands in that denies network access as well as write access outside the
 # build/ directory.
+#
+# The mount order of /tmp and CURDIR is important. It is reasonable for someone
+# to check this repository out under /tmp and try to build it. If this only has
+# `--ro-bind / / --tmpfs /tmp` without `--ro-bind "$(CURDIR)" "$(CURDIR)"`,
+# the sandbox will not contain any source code and the build will fail. Mounting
+# in this order leaves the source code available and /tmp writable.
 BWRAP := bwrap                                                               \
          --ro-bind / /                                                       \
          --tmpfs /tmp                                                        \

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,8 @@ BUILD_SUBDIRS := kernel runner third_party tools userspace
 # build/ directory.
 BWRAP := bwrap                                                               \
          --ro-bind / /                                                       \
+         --tmpfs /tmp                                                        \
+         --ro-bind "$(CURDIR)" "$(CURDIR)"                                   \
          --bind "$(CURDIR)/build" "$(CURDIR)/build"                          \
          --bind "$(CURDIR)/kernel/Cargo.lock" "$(CURDIR)/kernel/Cargo.lock"  \
          --bind "$(CURDIR)/runner/Cargo.lock" "$(CURDIR)/runner/Cargo.lock"  \
@@ -38,7 +40,6 @@ BWRAP := bwrap                                                               \
          --bind "$(CURDIR)/userspace/Cargo.lock"                             \
                 "$(CURDIR)/userspace/Cargo.lock"                             \
          --dev /dev                                                          \
-         --tmpfs /tmp                                                        \
          --unshare-all
 
 # A target that sets up directories the bwrap sandbox needs.


### PR DESCRIPTION
Previously, the sandbox caused builds to fail (with a very confusing error message) if you checked out tock-on-titan under `/tmp`. The problem is the mount of `/tmp` in the sandbox hid the source code. With this change, `/tmp` and the source code are both visible and usable.

This change has no effect on builds outside `/tmp`.

```
----------------------
`make prtest` summary:
----------------------
git rev-parse HEAD
dfe90632efff924c82c1a8af40fe5ebd2097db58
git status
On branch tmp-build-fix
Your branch is up to date with 'origin/tmp-build-fix'.

nothing to commit, working tree clean
```