### PR TITLE
kernel: Add dynamic SPI device AddressConfig via capsule.

### DIFF
--- a/kernel/h1/src/hil/spi_device.rs
+++ b/kernel/h1/src/hil/spi_device.rs
@@ -1,27 +1,7 @@
 //! Interfaces for SPI device on H1
 
+use spiutils::driver::AddressConfig;
 use spiutils::protocol::flash::AddressMode;
-
-/// Address configuration for SPI device hardware.
-#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
-pub struct AddressConfig {
-    /// The address on the SPI device bus that the external flash is accessible at.
-    pub flash_virtual_base: u32,
-
-    /// The base address in the external flash device on the SPI host bus.
-    pub flash_physical_base: u32,
-
-    /// The size of the external flash device.
-    /// This must be a 2^N.
-    pub flash_physical_size: u32,
-
-    /// The address on the SPI device bus that the RAM (mailbox) is accessible at.
-    pub ram_virtual_base: u32,
-
-    /// The total size available on the SPI device bus.
-    /// This must be a 2^N.
-    pub virtual_size: u32,
-}
 
 pub trait SpiDeviceClient {
     /// Called when data from the SPI host is available.

--- a/kernel/h1/src/spi_device.rs
+++ b/kernel/h1/src/spi_device.rs
@@ -1,4 +1,3 @@
-use crate::hil::spi_device::AddressConfig;
 use crate::hil::spi_device::SpiDevice;
 use crate::hil::spi_device::SpiDeviceClient;
 
@@ -13,6 +12,7 @@ use kernel::common::registers::WriteOnly;
 use kernel::common::StaticRef;
 use kernel::ReturnCode;
 
+use spiutils::driver::AddressConfig;
 use spiutils::protocol::flash::AddressMode;
 use spiutils::protocol::flash::OpCode;
 


### PR DESCRIPTION
This change removed the hard-coded AddressConfig from the kernel
and instead uses the common code in spiutils. This allows userspace
to configure the SPI device address configuration at runtime using
information acquired from connected hardware, e.g. a SPI flash
chip.
