### PR TITLE
otpilot: Use dynamic SPI device AddressConfig.

### DIFF
--- a/shared-lib/spiutils/src/driver.rs
+++ b/shared-lib/spiutils/src/driver.rs
@@ -25,6 +25,7 @@ use crate::protocol::wire::ToWire;
 
 use core::convert::TryFrom;
 use core::default::Default;
+use core::mem;
 
 /// Handler mode.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
@@ -58,6 +59,9 @@ impl TryFrom<usize> for HandlerMode {
         }
     }
 }
+
+/// The length of an AddressConfig on the wire, in bytes.
+pub const ADDRESS_CONFIG_LEN: usize = 5 * mem::size_of::<u32>();
 
 /// Address configuration for SPI device hardware.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]

--- a/userspace/otpilot/src/spi_device.rs
+++ b/userspace/otpilot/src/spi_device.rs
@@ -16,14 +16,19 @@
 
 use core::cell::Cell;
 use core::convert::TryFrom;
+use core::mem;
 
 use libtock::result::TockError;
 use libtock::result::TockResult;
 use libtock::shared_memory::SharedMemory;
 use libtock::syscalls;
 
+use spiutils::driver::AddressConfig;
+use spiutils::driver::ADDRESS_CONFIG_LEN;
 use spiutils::driver::HandlerMode;
+use spiutils::io::Cursor;
 use spiutils::protocol::flash::AddressMode;
+use spiutils::protocol::wire::ToWire;
 
 pub const MAX_READ_BUFFER_SIZE: usize = 512;
 
@@ -68,6 +73,9 @@ pub trait SpiDevice {
 
     /// Set the SFDP data.
     fn set_sfdp(&self, data: &mut[u8]) -> TockResult<()>;
+
+    /// Configure SPI addresses.
+    fn configure_addresses(&self, address_config: AddressConfig) -> TockResult<()>;
 }
 
 // Get the static SpiDevice object.
@@ -86,6 +94,7 @@ mod command_nr {
     pub const SET_ADDRESS_MODE_HANDLING: usize = 5;
     pub const SET_JEDEC_ID: usize = 6;
     pub const SET_SFDP: usize = 7;
+    pub const CONFIGURE_ADDRESSES: usize = 8;
 }
 
 mod subscribe_nr {
@@ -277,6 +286,26 @@ impl SpiDevice for SpiDeviceImpl {
         let _write_buffer_share = syscalls::allow(DRIVER_NUMBER, allow_nr::WRITE_BUFFER, data)?;
 
         syscalls::command(DRIVER_NUMBER, command_nr::SET_SFDP, 0, 0)?;
+
+        Ok(())
+    }
+
+    fn configure_addresses(&self, address_config: AddressConfig) -> TockResult<()> {
+        let mut buf = [0u8; ADDRESS_CONFIG_LEN];
+
+        {
+            // Scope for cursor (which doesn't implement Drop).
+            // We need cursor to go out of scope so that we can use buf further down.
+            let cursor = Cursor::new(&mut buf);
+            if address_config.to_wire(cursor).is_err() {
+                return Err(TockError::Format);
+            }
+        }
+
+        // We want this to go out of scope after executing the command
+        let _write_buffer_share = syscalls::allow(DRIVER_NUMBER, allow_nr::WRITE_BUFFER, &mut buf)?;
+
+        syscalls::command(DRIVER_NUMBER, command_nr::CONFIGURE_ADDRESSES, 0, 0)?;
 
         Ok(())
     }

--- a/userspace/otpilot/src/spi_device.rs
+++ b/userspace/otpilot/src/spi_device.rs
@@ -16,7 +16,6 @@
 
 use core::cell::Cell;
 use core::convert::TryFrom;
-use core::mem;
 
 use libtock::result::TockError;
 use libtock::result::TockResult;
@@ -302,7 +301,8 @@ impl SpiDevice for SpiDeviceImpl {
             }
         }
 
-        // We want this to go out of scope after executing the command
+        // We want this to go out of scope only AFTER executing the command,
+        // so assign it to an unused variable to keep the result object around.
         let _write_buffer_share = syscalls::allow(DRIVER_NUMBER, allow_nr::WRITE_BUFFER, &mut buf)?;
 
         syscalls::command(DRIVER_NUMBER, command_nr::CONFIGURE_ADDRESSES, 0, 0)?;

--- a/userspace/otpilot/src/spi_processor.rs
+++ b/userspace/otpilot/src/spi_processor.rs
@@ -45,11 +45,11 @@ use spiutils::protocol::wire::ToWireError;
 
 // Size of the SPI flash chip.
 // Hard-coded to 64 MiB for now.
-// TODO: Modify this to be read from the actual SPI flash chip at runtime.
+// TODO(osenft): Modify this to be read from the actual SPI flash chip at runtime.
 pub const SPI_FLASH_SIZE: u32 = 0x4000000;
 
 // The location of the mailbox.
-// TODO: Make this configurable, possibly by reading it from the SPI flash chip.
+// TODO(osenft): Make this configurable, possibly by reading it from the SPI flash chip.
 pub const SPI_MAILBOX_ADDRESS: u32 = 0xf00000;
 
 // The size of the mailbox.
@@ -236,6 +236,11 @@ impl<'a> SpiProcessor<'a> {
         Ok(())
     }
 
+    // Check if the specified address is within the mailbox address space.
+    fn is_mailbox_address(&self, addr: u32) -> bool {
+        addr >= SPI_MAILBOX_ADDRESS && addr < SPI_MAILBOX_ADDRESS + SPI_MAILBOX_SIZE
+    }
+
     fn process_spi_header<AddrType>(&mut self, header: &flash::Header::<AddrType>, rx_buf: &[u8]) -> SpiProcessorResult<()>
     where AddrType: Address {
         let mut data: &[u8] = rx_buf;
@@ -246,13 +251,13 @@ impl<'a> SpiProcessor<'a> {
         match header.opcode {
             OpCode::PageProgram => {
                 match header.get_address() {
-                    Some(x) if x >= SPI_MAILBOX_ADDRESS && x < SPI_MAILBOX_ADDRESS + SPI_MAILBOX_SIZE => {
+                    Some(addr) if self.is_mailbox_address(addr) => {
                         if spi_device::get().is_write_enable_set() {
                             self.process_spi_payload(data)?;
                         }
                         self.clear_device_status(true, true)
                     }
-                    Some(x) if x < SPI_MAILBOX_ADDRESS || x >= SPI_MAILBOX_ADDRESS + SPI_MAILBOX_SIZE => {
+                    Some(addr) if !self.is_mailbox_address(addr) => {
                         if spi_device::get().is_write_enable_set() {
                             // Pass through to SPI host
                             self.spi_host_write(header, data)?;
@@ -264,11 +269,11 @@ impl<'a> SpiProcessor<'a> {
             }
             OpCode::SectorErase | OpCode::BlockErase32KB | OpCode::BlockErase64KB => {
                 match header.get_address() {
-                    Some(x) if x >= SPI_MAILBOX_ADDRESS && x < SPI_MAILBOX_ADDRESS + SPI_MAILBOX_SIZE => {
+                    Some(addr) if self.is_mailbox_address(addr) => {
                         // Nothing to do.
                         self.clear_device_status(true, true)
                     }
-                    Some(x) if x < SPI_MAILBOX_ADDRESS || x >= SPI_MAILBOX_ADDRESS + SPI_MAILBOX_SIZE => {
+                    Some(addr) if !self.is_mailbox_address(addr) => {
                         if spi_device::get().is_write_enable_set() {
                             // Pass through to SPI host
                             self.spi_host_write(header, data)?;


### PR DESCRIPTION
This change prepares the otpilot code to enable dynamic configuration
of the SPI device addresses depending on the runtime configuration.
