### PR TITLE
Fix running `make check`.

### DIFF
--- a/userspace/Build.mk
+++ b/userspace/Build.mk
@@ -45,7 +45,7 @@ userspace/build-signed: userspace/build
 userspace/build-signed: $(addsuffix /build-signed,$(BUILD_SUBDIRS))
 
 .PHONY: userspace/check
-userspace/check: sandbox_setup
+userspace/check: build/gitlongtag sandbox_setup
 	cd userspace && TOCK_KERNEL_VERSION=h1_tests $(BWRAP) cargo check --release
 
 .PHONY: userspace/clean


### PR DESCRIPTION
`userspace/check` didn't have a dependency on `gitlongtag`, which it should have. This causes a build failure if you run `make userspace/check` in a clean repository, or if you run `make check` and get unlucky with build ordering.

```
----------------------
`make prtest` summary:
----------------------
git rev-parse HEAD
4fe7ac994b7858461d12b13938b72f720c83e346
git status
On branch check-fix
Your branch is up to date with 'origin/check-fix'.

nothing to commit, working tree clean
```
