### PR TITLE
otpilot: Add GPIO handling.

### DIFF
--- a/userspace/otpilot/src/gpio.rs
+++ b/userspace/otpilot/src/gpio.rs
@@ -120,24 +120,30 @@ fn get_impl() -> &'static GpioControlImpl {
 }
 
 
+/// Adds one event.
+/// If the maximum number of events would be exceeded, do nothing.
 fn add_event(events: &Cell<usize>) {
     let val = events.get();
-    events.set(val + 1);
+    if val < core::usize::MAX - 1 {
+        events.set(val + 1);
+    }
 }
 
+/// Consumes one event.
+/// Returns the number of events to consume before consuming one.
 fn delete_event(events: &Cell<usize>) -> usize {
     let val = events.get();
-    if val > 0 {
+    if val > core::usize::MIN {
         events.set(val - 1);
     }
     val
 }
 
+/// Clears all events.
+/// Returns the number of events to consume before clearing them.
 fn clear_event(events: &Cell<usize>) -> usize {
     let val = events.get();
-    if val > 0 {
-        events.set(0);
-    }
+    events.set(core::usize::MIN);
     val
 }
 

--- a/userspace/otpilot/src/gpio.rs
+++ b/userspace/otpilot/src/gpio.rs
@@ -1,0 +1,217 @@
+// Copyright 2021 lowRISC contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use core::cell::Cell;
+use core::convert::TryFrom;
+
+use libtock::gpio::GpioPinUnitialized;
+use libtock::gpio::GpioPinRead;
+use libtock::gpio::GpioPinWrite;
+use libtock::gpio::{IrqMode, InputMode};
+use libtock::result::TockError;
+use libtock::result::TockResult;
+
+/// GPIO pins.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+#[allow(non_camel_case_types)]
+pub enum GpioPin {
+    BMC_SRST_N = 0,
+    BMC_CPU_RST_N = 1,
+    SYS_RSTMON_N = 2,
+    BMC_RSTMON_N = 3,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+#[allow(dead_code)]
+pub enum GpioValue {
+    Low,
+    High,
+}
+
+pub trait GpioControl {
+    /// Check if there are any events to be consumed.
+    fn have_events(&self) -> bool;
+
+    /// Consume one event on the specified pin.
+    /// Returns true if there was an event to be consumed.
+    fn consume_event(&self, pin: GpioPin) -> bool;
+
+    /// Clear all events on the specified pin.
+    /// Returns true if there was an event.
+    fn clear_event(&self, pin: GpioPin) -> bool;
+
+    /// Set GpioPin value.
+    fn set(&self, pin: GpioPin, val: GpioValue) -> TockResult<()>;
+}
+
+// Get the static GpioControl object.
+pub fn get() -> &'static dyn GpioControl {
+    get_impl()
+}
+
+/// Error for invalid GpioPin conversion.
+pub struct InvalidGpioPin;
+
+impl TryFrom<usize> for GpioPin {
+    type Error = InvalidGpioPin;
+
+    fn try_from(item: usize) -> Result<GpioPin, Self::Error> {
+        match item {
+            0 => Ok(GpioPin::BMC_SRST_N),
+            1 => Ok(GpioPin::BMC_CPU_RST_N),
+            2 => Ok(GpioPin::SYS_RSTMON_N),
+            3 => Ok(GpioPin::BMC_RSTMON_N),
+            _ => Err(InvalidGpioPin),
+        }
+    }
+}
+
+impl From<GpioPin> for usize {
+    fn from(item: GpioPin) -> usize {
+        item as usize
+    }
+}
+
+
+struct GpioControlImpl {
+    bmc_srst_n: Option<GpioPinWrite>,
+    bmc_cpu_rst_n: Option<GpioPinWrite>,
+    sys_rstmon_n: Option<GpioPinRead>,
+    bmc_rstmon_n: Option<GpioPinRead>,
+
+    sys_rstmon_n_events: Cell<usize>,
+    bmc_rstmon_n_events: Cell<usize>,
+}
+
+static mut GPIO_CTRL: GpioControlImpl = GpioControlImpl {
+    bmc_srst_n: None,
+    bmc_cpu_rst_n: None,
+    sys_rstmon_n: None,
+    bmc_rstmon_n: None,
+    sys_rstmon_n_events: Cell::new(0),
+    bmc_rstmon_n_events: Cell::new(0),
+};
+
+static mut IS_INITIALIZED: bool = false;
+
+fn get_impl() -> &'static GpioControlImpl {
+    unsafe {
+        if !IS_INITIALIZED {
+            if GPIO_CTRL.initialize().is_err() {
+                panic!("Could not initialize GPIO Control");
+            }
+            IS_INITIALIZED = true;
+        }
+        &GPIO_CTRL
+    }
+}
+
+
+fn add_event(events: &Cell<usize>) {
+    let val = events.get();
+    events.set(val + 1);
+}
+
+fn delete_event(events: &Cell<usize>) -> usize {
+    let val = events.get();
+    if val > 0 {
+        events.set(val - 1);
+    }
+    val
+}
+
+fn clear_event(events: &Cell<usize>) -> usize {
+    let val = events.get();
+    if val > 0 {
+        events.set(0);
+    }
+    val
+}
+
+impl GpioControlImpl {
+    fn initialize(&'static mut self) -> TockResult<()> {
+        self.bmc_srst_n = Some(GpioPinUnitialized::new(GpioPin::BMC_SRST_N as usize).open_for_write()?);
+        self.bmc_cpu_rst_n = Some(GpioPinUnitialized::new(GpioPin::BMC_CPU_RST_N as usize).open_for_write()?);
+        self.sys_rstmon_n = Some(GpioPinUnitialized::new(GpioPin::SYS_RSTMON_N as usize).open_for_read(
+            Some((GpioControlImpl::event_trampoline, IrqMode::RisingEdge)),
+            InputMode::PullNone)?);
+        self.bmc_rstmon_n = Some(GpioPinUnitialized::new(GpioPin::BMC_RSTMON_N as usize).open_for_read(
+            Some((GpioControlImpl::event_trampoline, IrqMode::RisingEdge)),
+            InputMode::PullNone)?);
+        Ok(())
+    }
+
+    extern "C" fn event_trampoline(pin_num: usize, pin_state: usize, _: usize, _: usize) {
+        get_impl().event(pin_num, pin_state);
+    }
+
+    fn event(&self, pin_num: usize, _pin_state: usize) {
+        let pin = match GpioPin::try_from(pin_num) {
+            Ok(val) => val,
+            Err(_) => return,
+        };
+
+        match pin {
+            GpioPin::SYS_RSTMON_N => add_event(&self.sys_rstmon_n_events),
+            GpioPin::BMC_RSTMON_N => add_event(&self.bmc_rstmon_n_events),
+            _ => (),
+        };
+    }
+
+    fn set_value(&self, maybe_pin: &Option<GpioPinWrite>, val: GpioValue) -> TockResult<()> {
+        if let Some(pin) = maybe_pin {
+            match val {
+                GpioValue::Low => pin.set_low(),
+                GpioValue::High => pin.set_high(),
+            }
+        } else {
+            Err(TockError::Format)
+        }
+    }
+}
+
+impl GpioControl for GpioControlImpl {
+
+    fn have_events(&self) -> bool {
+        self.sys_rstmon_n_events.get() != 0 || self.bmc_rstmon_n_events.get() != 0
+    }
+
+    fn consume_event(&self, pin: GpioPin) -> bool {
+        let val = match pin {
+            GpioPin::SYS_RSTMON_N => delete_event(&self.sys_rstmon_n_events),
+            GpioPin::BMC_RSTMON_N => delete_event(&self.bmc_rstmon_n_events),
+            _ => 0,
+        };
+        val != 0
+    }
+
+    fn clear_event(&self, pin: GpioPin) -> bool {
+        let val = match pin {
+            GpioPin::SYS_RSTMON_N => clear_event(&self.sys_rstmon_n_events),
+            GpioPin::BMC_RSTMON_N => clear_event(&self.bmc_rstmon_n_events),
+            _ => 0,
+        };
+        val != 0
+    }
+
+    fn set(&self, pin: GpioPin, val: GpioValue) -> TockResult<()> {
+        match pin {
+            GpioPin::BMC_SRST_N => self.set_value(&self.bmc_srst_n, val),
+            GpioPin::BMC_CPU_RST_N => self.set_value(&self.bmc_cpu_rst_n, val),
+            _ => Ok(()),
+        }
+    }
+}

--- a/userspace/otpilot/src/gpio_processor.rs
+++ b/userspace/otpilot/src/gpio_processor.rs
@@ -1,0 +1,142 @@
+// Copyright 2021 lowRISC contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::alarm;
+use crate::gpio;
+use crate::gpio::GpioPin;
+use crate::gpio::GpioValue;
+use crate::spi_device;
+use crate::spi_host_h1;
+use crate::spi_host_helper::SpiHostHelper;
+
+use core::cell::Cell;
+use core::fmt::Write;
+
+use libtock::console::Console;
+use libtock::result::TockResult;
+
+use spiutils::protocol::flash::AddressMode;
+
+pub struct GpioProcessor {
+    /// Whether to ignore bmc_rstmon_n events
+    ignore_bmc_rstmon_n_events: Cell<bool>,
+
+    /// The initial address mode after resetting the BMC.
+    initial_address_mode: AddressMode,
+
+    /// Alarm ticks
+    alarm_ticks: usize,
+}
+
+const ALARM_MSECS: u64 = 62;
+const MSECS_IN_SEC: u64 = 1000;
+
+impl GpioProcessor {
+    pub fn new() -> GpioProcessor {
+        let alarm_ticks: u64 =
+            ((alarm::get().get_clock_frequency() as u64) * ALARM_MSECS) / MSECS_IN_SEC;
+
+        GpioProcessor {
+            ignore_bmc_rstmon_n_events: Cell::new(false),
+            initial_address_mode: spi_device::get().get_address_mode(),
+            alarm_ticks: alarm_ticks as usize,
+        }
+    }
+
+    fn set_alarm(&self) -> TockResult<()> {
+        self.ignore_bmc_rstmon_n_events.set(true);
+        alarm::get().set(self.alarm_ticks)
+    }
+
+    pub fn set_bmc_cpu_rst(&self, asserted: bool) -> TockResult<()> {
+        if asserted {
+            gpio::get().set(GpioPin::BMC_CPU_RST_N, GpioValue::Low)?;
+        } else  {
+            gpio::get().set(GpioPin::BMC_CPU_RST_N, GpioValue::High)?;
+            self.set_alarm()?;
+        }
+
+        Ok(())
+    }
+
+    pub fn set_bmc_srst(&self, asserted: bool) -> TockResult<()> {
+        if asserted {
+            gpio::get().set(GpioPin::BMC_SRST_N, GpioValue::Low)?;
+        } else  {
+            gpio::get().set(GpioPin::BMC_SRST_N, GpioValue::High)?;
+            self.set_alarm()?;
+        }
+
+        Ok(())
+    }
+
+    fn handle_bmc_rstmon(&self) -> TockResult<()> {
+        // Put BMC into reset
+        self.set_bmc_cpu_rst(true)?;
+
+        // Disable SPI passthrough
+        spi_host_h1::get().set_passthrough(false)?;
+
+        // Read some stuff from the SPI host
+        // TODO: Do something more useful with the data (e.g. checksum) here.
+        let host_helper = SpiHostHelper {};
+        host_helper.enter_4b()?;
+        host_helper.read_and_print_data(0x0)?;
+
+        // Set expected initial address mode
+        let host_helper = SpiHostHelper {};
+        match self.initial_address_mode {
+            AddressMode::ThreeByte => host_helper.exit_4b()?,
+            AddressMode::FourByte => host_helper.enter_4b()?,
+        }
+        spi_device::get().set_address_mode(self.initial_address_mode)?;
+
+        // Enable SPI passthrough
+        spi_host_h1::get().set_passthrough(true)?;
+
+        // We don't care about any events that may have happened during reset.
+        gpio::get().clear_event(GpioPin::BMC_RSTMON_N);
+
+        // Let BMC out of reset
+        self.set_bmc_cpu_rst(false)?;
+
+        Ok(())
+    }
+
+    pub fn process_gpio_events(&self) -> TockResult<()> {
+        let mut console = Console::new();
+
+        let bmc_rstmon_n = gpio::get().consume_event(GpioPin::BMC_RSTMON_N);
+        if bmc_rstmon_n {
+            if self.ignore_bmc_rstmon_n_events.get() {
+                writeln!(console, "Ignored bmc_rstmon_n")?;
+            } else {
+                writeln!(console, "Handling bmc_rstmon_n")?;
+                self.handle_bmc_rstmon()?;
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn alarm_expired(&self) -> TockResult<()> {
+        let mut console = Console::new();
+
+        writeln!(console, "GPIO: alarm expired")?;
+        self.ignore_bmc_rstmon_n_events.set(false);
+        alarm::get().clear()
+    }
+}


### PR DESCRIPTION
This change adds the GPIO driver as well as a GPIO processor that handles
BMC reset monitor events.
