### PR TITLE
kernel: Add Reset component and capsule.

### DIFF
--- a/kernel/h1/src/hil/mod.rs
+++ b/kernel/h1/src/hil/mod.rs
@@ -19,6 +19,7 @@ pub mod flash;
 pub mod fuse;
 pub mod globalsec;
 pub mod personality;
+pub mod reset;
 pub mod rng;
 pub mod spi_host;
 pub mod spi_device;

--- a/kernel/h1/src/hil/reset.rs
+++ b/kernel/h1/src/hil/reset.rs
@@ -16,10 +16,12 @@
 
 //! Interfaces for reset monitor and execution on H1
 
+use spiutils::driver::reset::ResetSource;
+
 pub trait Reset {
     /// Immediately reset chip.
     fn reset_chip(&self) -> !;
 
-    /// Get source of last reset.
-    fn get_reset_source(&self) -> u8;
+    /// Get source of the last reset.
+    fn get_reset_source(&self) -> ResetSource;
 }

--- a/kernel/h1/src/hil/reset.rs
+++ b/kernel/h1/src/hil/reset.rs
@@ -18,7 +18,7 @@
 
 pub trait Reset {
     /// Immediately reset chip.
-    fn reset(&self) -> !;
+    fn reset_chip(&self) -> !;
 
     /// Get source of last reset.
     fn get_reset_source(&self) -> u8;

--- a/kernel/h1/src/hil/reset.rs
+++ b/kernel/h1/src/hil/reset.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2021 lowRISC contributors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,24 +11,15 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
-#![no_std]
+//! Interfaces for reset monitor and execution on H1
 
-extern crate h1;
-#[macro_use(static_init, debug)]
-extern crate kernel;
+pub trait Reset {
+    /// Immediately reset chip.
+    fn reset(&self) -> !;
 
-pub mod digest;
-pub mod aes;
-pub mod dcrypto;
-pub mod dcrypto_test;
-pub mod fuse;
-pub mod globalsec;
-pub mod nvcounter_syscall;
-pub mod personality;
-pub mod reset;
-pub mod spi_host;
-pub mod spi_device;
-
-pub unsafe fn init() {
+    /// Get source of last reset.
+    fn get_reset_source(&self) -> u8;
 }

--- a/kernel/h1/src/pmu.rs
+++ b/kernel/h1/src/pmu.rs
@@ -45,6 +45,7 @@ use crate::hil::reset;
 
 use core::mem::transmute;
 use kernel::common::cells::VolatileCell;
+use spiutils::driver::reset::ResetSource;
 
 /// Magic value (as defined by the H1 spec) to initiate a reset
 /// via the global_reset register .
@@ -316,7 +317,17 @@ impl reset::Reset for ResetImpl {
     }
 
     /// Get source of last reset.
-    fn get_reset_source(&self) -> u8 {
-        self.reset_source
+    fn get_reset_source(&self) -> ResetSource {
+        ResetSource {
+            // The individual bits are defined in the H1 spec.
+            power_on_reset: (self.reset_source & 0x1) != 0,
+            low_power_reset: (self.reset_source & 0x2) != 0,
+            watchdog_reset: (self.reset_source & 0x4) != 0,
+            lockup_reset: (self.reset_source & 0x8) != 0,
+            sysreset: (self.reset_source & 0x10) != 0,
+            software_reset: (self.reset_source & 0x20) != 0,
+            fast_burnout_circuit: (self.reset_source & 0x40) != 0,
+            security_breach_reset: (self.reset_source & 0x80) != 0,
+        }
     }
 }

--- a/kernel/h1_syscalls/src/reset.rs
+++ b/kernel/h1_syscalls/src/reset.rs
@@ -1,0 +1,70 @@
+// Copyright 2021 lowRISC contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use h1::hil::reset::Reset;
+use kernel::{AppId, AppSlice, Callback, Driver, ReturnCode, Shared};
+
+pub const DRIVER_NUM: usize = 0x40070;
+
+pub struct ResetSyscall<'a> {
+    reset: &'a dyn Reset,
+}
+
+impl<'a> ResetSyscall<'a> {
+    pub fn new(reset: &'a dyn Reset) -> ResetSyscall<'a> {
+        ResetSyscall {
+            reset: reset,
+        }
+    }
+
+    fn reset(&self) -> ReturnCode {
+        self.reset.reset();
+
+        // This should never return. If it did, something went wrong.
+    }
+
+    fn get_reset_source(&self) -> ReturnCode {
+        ReturnCode::SuccessWithValue { value: self.reset.get_reset_source() as usize }
+    }
+}
+
+impl<'a> Driver for ResetSyscall<'a> {
+    fn subscribe(&self,
+                 _subscribe_num: usize,
+                 _callback: Option<Callback>,
+                 _app_id: AppId,
+    ) -> ReturnCode {
+        ReturnCode::ENOSUPPORT
+    }
+
+    fn command(&self, command_num: usize, _arg1: usize, _arg2: usize, _caller_id: AppId)
+        -> ReturnCode {
+        match command_num {
+            0 /* Check if present */ => ReturnCode::SUCCESS,
+            1 /* Reset chip. */ => self.reset(),
+            2 /* Get reset source */ => self.get_reset_source(),
+            _ => ReturnCode::ENOSUPPORT
+        }
+    }
+
+    fn allow(&self,
+             _app_id: AppId,
+             _minor_num: usize,
+             _slice: Option<AppSlice<Shared, u8>>
+    ) -> ReturnCode {
+        ReturnCode::ENOSUPPORT
+    }
+}

--- a/kernel/h1_syscalls/src/reset.rs
+++ b/kernel/h1_syscalls/src/reset.rs
@@ -30,10 +30,11 @@ impl<'a> ResetSyscall<'a> {
         }
     }
 
-    fn reset(&self) -> ReturnCode {
-        self.reset.reset();
+    fn reset_chip(&self) -> ReturnCode {
+        self.reset.reset_chip();
 
-        // This should never return. If it did, something went wrong.
+        // The above call never returns (return type "!"), so there's
+        // no ReturnCode to provide here.
     }
 
     fn get_reset_source(&self) -> ReturnCode {
@@ -54,7 +55,7 @@ impl<'a> Driver for ResetSyscall<'a> {
         -> ReturnCode {
         match command_num {
             0 /* Check if present */ => ReturnCode::SUCCESS,
-            1 /* Reset chip. */ => self.reset(),
+            1 /* Reset chip. */ => self.reset_chip(),
             2 /* Get reset source */ => self.get_reset_source(),
             _ => ReturnCode::ENOSUPPORT
         }

--- a/kernel/papa/src/main.rs
+++ b/kernel/papa/src/main.rs
@@ -104,6 +104,7 @@ pub struct Papa {
     personality: &'static h1_syscalls::personality::PersonalitySyscall<'static>,
     fuse_syscalls: &'static h1_syscalls::fuse::FuseSyscall<'static>,
     globalsec_syscalls: &'static h1_syscalls::globalsec::GlobalSecSyscall<'static>,
+    reset_syscalls: &'static h1_syscalls::reset::ResetSyscall<'static>,
 }
 
 fn get_h1_flash_segment_info(identifier: SegmentAndLocation, address: u32, size: u32) -> SegmentInfo {
@@ -398,6 +399,12 @@ pub unsafe fn reset_handler() {
         h1_syscalls::globalsec::GlobalSecSyscall::new(&h1::globalsec::GLOBALSEC, kernel.create_grant(&grant_cap))
     );
 
+    h1::pmu::RESET.init();
+    let reset_syscalls = static_init!(
+        h1_syscalls::reset::ResetSyscall<'static>,
+        h1_syscalls::reset::ResetSyscall::new(&h1::pmu::RESET)
+    );
+
     let mut _ctr = 0;
     let chip = static_init!(h1::chip::Hotel, h1::chip::Hotel::new());
     chip.mpu().enable_mpu();
@@ -424,6 +431,7 @@ pub unsafe fn reset_handler() {
         personality: personality,
         fuse_syscalls: fuse_syscalls,
         globalsec_syscalls: globalsec_syscalls,
+        reset_syscalls: reset_syscalls,
     };
 
     // Uncomment to initialize NvCounter
@@ -476,6 +484,7 @@ impl Platform for Papa {
             h1_syscalls::personality::DRIVER_NUM       => f(Some(self.personality)),
             h1_syscalls::fuse::DRIVER_NUM              => f(Some(self.fuse_syscalls)),
             h1_syscalls::globalsec::DRIVER_NUM         => f(Some(self.globalsec_syscalls)),
+            h1_syscalls::reset::DRIVER_NUM             => f(Some(self.reset_syscalls)),
             kernel::ipc::DRIVER_NUM                    => f(Some(&self.ipc)),
             _ =>  f(None),
         }

--- a/kernel/papa/src/main.rs
+++ b/kernel/papa/src/main.rs
@@ -402,7 +402,7 @@ pub unsafe fn reset_handler() {
     h1::pmu::RESET.init();
     let reset_syscalls = static_init!(
         h1_syscalls::reset::ResetSyscall<'static>,
-        h1_syscalls::reset::ResetSyscall::new(&h1::pmu::RESET)
+        h1_syscalls::reset::ResetSyscall::new(&h1::pmu::RESET, kernel.create_grant(&grant_cap))
     );
 
     let mut _ctr = 0;


### PR DESCRIPTION
This adds a HIL, implementation and capsule to execute a chip reset and to get the source of the last reset.

Depends on PR #237.