### PR TITLE
kernel/h1: Add support for both flash banks.

### DIFF
--- a/kernel/h1/src/hil/flash/driver.rs
+++ b/kernel/h1/src/hil/flash/driver.rs
@@ -18,6 +18,7 @@ use core::cmp;
 use ::kernel::common::cells::TakeCell;
 use ::kernel::hil::time::Alarm;
 use ::kernel::ReturnCode;
+use super::hardware::Bank;
 use super::hardware::Hardware;
 use super::smart_program::SmartProgramState;
 
@@ -30,7 +31,9 @@ pub struct FlashImpl<'d, A: Alarm<'d> + 'd, H: Hardware + 'd> {
     write_data: TakeCell<'d, [u32]>,
     write_pos: Cell<usize>,
     write_len: Cell<usize>,
-    write_target: Cell<usize>,
+    write_bank: Cell<Bank>,
+    // Target address within the bank.
+    write_bank_target: Cell<usize>,
     // Hardware interface. Uses shared references rather than mutable references
     // because the fake interface used in the unit tests is shared with the unit
     // tests.
@@ -54,7 +57,8 @@ impl<'d, A: Alarm<'d>, H: Hardware> FlashImpl<'d, A, H> {
             write_data: TakeCell::empty(),
             write_pos: Cell::new(0),
             write_len: Cell::new(0),
-            write_target: Cell::new(0),
+            write_bank: Cell::new(Bank::Zero),
+            write_bank_target: Cell::new(0),
             hw,
             smart_program_state: Cell::new(None),
             opcode: Cell::new(0)
@@ -67,11 +71,13 @@ const WORDS_PER_BANK: usize = 0x10000; // 64ki words per bank
 
 // Computes the flash Bank for the specified target location in words
 // from the beginning of flash.
-fn get_bank_from_target(target: usize) -> super::hardware::Bank {
+fn get_bank_from_target(target: usize) -> Option<Bank> {
     if target < WORDS_PER_BANK {
-        super::hardware::Bank::Zero
+        Some(Bank::Zero)
+    } else if target < 2 * WORDS_PER_BANK {
+        Some(Bank::One)
     } else {
-        super::hardware::Bank::One
+        None
     }
 }
 
@@ -79,10 +85,18 @@ impl<'d, A: Alarm<'d>, H: Hardware> super::flash::Flash<'d> for FlashImpl<'d, A,
     fn erase(&self, page: usize) -> ReturnCode {
         if self.program_in_progress() { return ReturnCode::EBUSY; }
         let target: usize = page * super::WORDS_PER_PAGE;
-        self.write_target.set(target);
+
+        let maybe_bank = get_bank_from_target(target);
+        if maybe_bank.is_none() {
+            return ReturnCode::EINVAL;
+        }
+
+        self.write_bank.set(maybe_bank.unwrap());
+        self.write_bank_target.set(target % WORDS_PER_BANK);
         self.smart_program(ERASE_OPCODE, /*max_attempts*/ 45, /*final_pulse_needed*/ false,
-                           /*timeout_nanoseconds*/ 3_353_267,
-                           /*target*/ target, /*size*/ 1);
+                           /*timeout_nanoseconds*/ 3_353_267, self.write_bank.get(),
+                           /*bank_target*/ self.write_bank_target.get(), /*size*/ 1);
+
         ReturnCode::SUCCESS
     }
 
@@ -95,15 +109,23 @@ impl<'d, A: Alarm<'d>, H: Hardware> super::flash::Flash<'d> for FlashImpl<'d, A,
 
         if data.len() > MAX_WRITE_SIZE { return (ReturnCode::ESIZE, Some(data)); }
         if self.program_in_progress() { return (ReturnCode::EBUSY, Some(data)); }
+
+        let maybe_bank = get_bank_from_target(target);
+        if maybe_bank.is_none() {
+            return (ReturnCode::EINVAL, Some(data));
+        }
+
         self.write_pos.set(0);
-        self.write_target.set(target);
+        self.write_bank.set(maybe_bank.unwrap());
+        self.write_bank_target.set(target % WORDS_PER_BANK);
         self.write_len.set(write_len);
         self.hw.set_write_data(&data[0..write_len]);
         self.write_data.replace(data);
 
         self.smart_program(WRITE_OPCODE, /*max_attempts*/ 8, /*final_pulse_needed*/ true,
                            /*timeout_nanoseconds*/ 48734 + write_len as u32 * 3734,
-                           target, write_len);
+                           self.write_bank.get(), self.write_bank_target.get(), write_len);
+
         (ReturnCode::SUCCESS, None)
     }
 
@@ -123,7 +145,7 @@ impl<'d, A: Alarm<'d>, H: Hardware> ::kernel::hil::time::AlarmClient for FlashIm
     fn fired(&self) {
         if let Some(state) = self.smart_program_state.take() {
             let state = state.step(
-                self.alarm, self.hw, self.opcode.get(), get_bank_from_target(self.write_target.get()));
+                self.alarm, self.hw, self.opcode.get(), self.write_bank.get());
             if let Some(code) = state.return_code() {
                 if let Some(client) = self.client.get() {
                     if self.opcode.get() == WRITE_OPCODE {
@@ -135,13 +157,13 @@ impl<'d, A: Alarm<'d>, H: Hardware> ::kernel::hil::time::AlarmClient for FlashIm
                         } else {
                             let next_len = cmp::min(MAX_WRITE_SIZE, fullwrite_end - subwrite_end);
                             let next_end = subwrite_end + next_len;
-                            let target = self.write_target.get() + subwrite_end;
+                            let target = self.write_bank_target.get() + subwrite_end;
                             self.write_pos.set(subwrite_end);
                             self.write_data.map(|d|
                                                 self.hw.set_write_data(&d[subwrite_end..next_end]));
                             self.smart_program(WRITE_OPCODE, /*max_attempts*/ 8, /*final_pulse_needed*/ true,
                                                /*timeout_nanoseconds*/ 48734 + next_len as u32 * 3734,
-                                               target, next_len);
+                                               self.write_bank.get(), target, next_len);
                         }
                     } else {
                         client.erase_done(code);
@@ -168,14 +190,15 @@ impl<'d, A: Alarm<'d>, H: Hardware> FlashImpl<'d, A, H> {
 
     /// Begins the smart programming procedure. Note that size must be >= 1 to
     /// avoid underflow (use an arbitrary positive value for erases).
+    /// `bank_target` specifies the target address relative to the selected bank.
     fn smart_program(&self, opcode: u32, max_attempts: u8, final_pulse_needed: bool,
-                     timeout_nanoseconds: u32, target: usize, size: usize)
+                     timeout_nanoseconds: u32, bank: Bank, bank_target: usize, size: usize)
     {
         // Use the offset relative to the flash bank.
-        self.hw.set_transaction(target % WORDS_PER_BANK, size - 1);
+        self.hw.set_transaction(bank_target, size - 1);
         self.smart_program_state.set(Some(
             SmartProgramState::init(max_attempts, final_pulse_needed, timeout_nanoseconds)
-                .step(self.alarm, self.hw, opcode, get_bank_from_target(target))));
+                .step(self.alarm, self.hw, opcode, bank)));
         self.opcode.set(opcode);
     }
 }

--- a/kernel/h1/src/hil/flash/fake.rs
+++ b/kernel/h1/src/hil/flash/fake.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use kernel::ReturnCode;
+
 #[derive(Clone,Copy,Default)]
 struct LogEntry {
     /// The value of the operation. u32::MAX indicates this was an erase,
@@ -151,16 +153,26 @@ impl super::hardware::Hardware for FakeHw {
         out
     }
 
-    fn set_transaction(&self, offset: usize, size: usize) {
+    fn set_transaction(&self, offset: usize, size: usize) -> ReturnCode {
         self.transaction_offset.set(offset);
         self.transaction_size.set(size + 1);
+
+        ReturnCode::SUCCESS
     }
 
-    fn set_write_data(&self, data: &[u32]) {
+    fn set_write_data(&self, data: &[u32]) -> ReturnCode {
         for (i, &v) in data.iter().enumerate() { self.write_data[i].set(v); }
+
+        ReturnCode::SUCCESS
     }
 
-    fn trigger(&self, opcode: u32) {
+    fn trigger(&self, opcode: u32, offset: usize) -> ReturnCode {
+        if self.transaction_offset.get() != offset {
+            return ReturnCode::EINVAL
+        }
+
         self.opcode.set(opcode);
+
+        ReturnCode::SUCCESS
     }
 }

--- a/kernel/h1/src/hil/flash/fake.rs
+++ b/kernel/h1/src/hil/flash/fake.rs
@@ -21,7 +21,7 @@ struct LogEntry {
     value: u32,
 
     /// The operation's target bank.
-    bank: Bank,
+    bank: Option<Bank>,
 
     /// The operation's offset. This is in units of words from the start of
     /// flash.
@@ -36,7 +36,7 @@ pub struct FakeHw {
     // Currently-executing opcode; 0 if no transaction is ongoing.
     opcode: core::cell::Cell<u32>,
 
-    transaction_bank: core::cell::Cell<Bank>,
+    transaction_bank: core::cell::Cell<Option<Bank>>,
     transaction_bank_offset: core::cell::Cell<usize>,
     transaction_size: core::cell::Cell<usize>,
     write_data: [core::cell::Cell<u32>; 32],
@@ -170,7 +170,7 @@ impl super::hardware::Hardware for FakeHw {
     }
 
     fn trigger(&self, opcode: u32, bank: Bank) {
-        self.transaction_bank.set(bank);
+        self.transaction_bank.set(Some(bank));
         self.opcode.set(opcode);
     }
 }

--- a/kernel/h1/src/hil/flash/h1_hw.rs
+++ b/kernel/h1/src/hil/flash/h1_hw.rs
@@ -31,6 +31,8 @@ pub const H1_INFO_0_START: usize    = 0x20000;
 pub const H1_INFO_1_START: usize    = 0x28000;
 pub const H1_INFO_SIZE: usize       = 0x00800;
 
+const BYTES_PER_WORD: usize = core::mem::size_of::<u32>();
+
 register_bitfields![u32,
     TransactionParameters [
         Offset OFFSET(0) NUMBITS(16) [],
@@ -42,7 +44,7 @@ register_bitfields![u32,
 #[repr(C)]
 pub struct H1bHw {
     /// Read/Program/Erase control for flash macro 0.
-    _pe_control_0: VolatileCell<u32>,
+    pe_control_0: VolatileCell<u32>,
 
     /// Read/Program/Erase control for flash macro 1.
     pe_control_1: VolatileCell<u32>,
@@ -243,8 +245,7 @@ pub struct H1bHw {
 
 impl super::hardware::Hardware for H1bHw {
     fn is_programming(&self) -> bool {
-        // TODO(jrvanwhy): Only checks the second flash bank.
-        self.pe_control_1.get() != 0
+        self.pe_control_0.get() != 0 || self.pe_control_1.get() != 0
     }
 
     fn read(&self, offset: usize) -> ReturnCode {
@@ -265,27 +266,56 @@ impl super::hardware::Hardware for H1bHw {
         self.error_code.get() as u16
     }
 
-    fn set_transaction(&self, offset: usize, size: usize) {
+    fn set_transaction(&self, offset: usize, size: usize) -> ReturnCode {
         use self::TransactionParameters::{Offset,Size};
-        // The offset is relative to the beginning of the flash module. There
-        // are 128 pages per flash module.
-        // TODO(jrvanwhy): Assumes the read is from the second flash bank.
-        if offset > H1_FLASH_SIZE {
-           return; // TODO(pal): Fails silently!
+        // The offset is relative to the beginning of the flash module.
+        if offset > H1_FLASH_SIZE / BYTES_PER_WORD {
+           return ReturnCode::EINVAL
         }
 
-        let offset = offset - 128 * super::WORDS_PER_PAGE;
-        self.transaction_parameters.write(Offset.val(offset as u32) + Size.val(size as u32));
+        if size > H1_FLASH_BANK_SIZE / BYTES_PER_WORD {
+            return ReturnCode::EINVAL
+        }
+
+        // Compute the offset relative to the flash bank.
+        let relative_offset: usize;
+        if offset < H1_FLASH_BANK_SIZE / BYTES_PER_WORD {
+            relative_offset = offset;
+        } else {
+            relative_offset = offset - H1_FLASH_BANK_SIZE / BYTES_PER_WORD;
+        }
+
+        if relative_offset + size > H1_FLASH_BANK_SIZE / BYTES_PER_WORD {
+            return ReturnCode::EINVAL
+        }
+
+        self.transaction_parameters.write(Offset.val(relative_offset as u32) + Size.val(size as u32));
+
+        ReturnCode::SUCCESS
     }
 
-    fn set_write_data(&self, data: &[u32]) {
+    fn set_write_data(&self, data: &[u32]) -> ReturnCode {
+        if data.len() > self.write_data.len() {
+            return ReturnCode::EINVAL
+        }
         for (i, &v) in data.iter().enumerate() { self.write_data[i].set(v); }
+
+        ReturnCode::SUCCESS
     }
 
-    fn trigger(&self, opcode: u32) {
+    fn trigger(&self, opcode: u32, offset: usize) -> ReturnCode {
         self.program_erase_enable.set(0xb11924e1);
-        // TODO(jrvanwhy): Assumes the write is to the second flash bank (where
-        // the nvmem counter is).
-        self.pe_control_1.set(opcode);
+        // The offset is relative to the beginning of the flash module.
+        if offset > H1_FLASH_SIZE / BYTES_PER_WORD {
+           return ReturnCode::EINVAL
+        }
+
+        if offset < H1_FLASH_BANK_SIZE / BYTES_PER_WORD {
+            self.pe_control_0.set(opcode);
+        } else {
+            self.pe_control_1.set(opcode);
+        }
+
+        ReturnCode::SUCCESS
     }
 }

--- a/kernel/h1/src/hil/flash/h1_hw.rs
+++ b/kernel/h1/src/hil/flash/h1_hw.rs
@@ -281,7 +281,6 @@ impl super::hardware::Hardware for H1bHw {
         // The offset is relative to the beginning of the flash module.
 
         match bank {
-            super::hardware::Bank::Unknown => debug!("H1bHw::trigger: Flash bank not set."),
             super::hardware::Bank::Zero => self.pe_control_0.set(opcode),
             super::hardware::Bank::One => self.pe_control_1.set(opcode),
         }

--- a/kernel/h1/src/hil/flash/hardware.rs
+++ b/kernel/h1/src/hil/flash/hardware.rs
@@ -17,13 +17,8 @@ use kernel::ReturnCode;
 /// The bank to perform an operation on.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub enum Bank {
-    Unknown,
     Zero,
     One,
-}
-
-impl Default for Bank {
-    fn default() -> Self { Bank::Unknown }
 }
 
 /// The interface between the flash driver and the (real or fake) flash module.

--- a/kernel/h1/src/hil/flash/hardware.rs
+++ b/kernel/h1/src/hil/flash/hardware.rs
@@ -14,8 +14,19 @@
 
 use kernel::ReturnCode;
 
-/// The interface between the flash driver and the (real or fake) flash module.
+/// The bank to perform an operation on.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+pub enum Bank {
+    Unknown,
+    Zero,
+    One,
+}
 
+impl Default for Bank {
+    fn default() -> Self { Bank::Unknown }
+}
+
+/// The interface between the flash driver and the (real or fake) flash module.
 pub trait Hardware {
     /// Returns true if an operation is running, false otherwise.
     fn is_programming(&self) -> bool;
@@ -28,14 +39,15 @@ pub trait Hardware {
     fn read_error(&self) -> u16;
 
     /// Set flash transaction parameters (word offset and size). The word offset
-    /// is relative to the start of flash and the size is one less than the
+    /// is relative to the start of a flash bank and the size is one less than the
     /// number of words to copy.
-    fn set_transaction(&self, offset: usize, size: usize) -> ReturnCode;
+    fn set_transaction(&self, bank_offset: usize, size: usize);
 
     /// Fill the flash controller's write buffer. data must have a length no
     /// larger than 32.
-    fn set_write_data(&self, data: &[u32]) -> ReturnCode;
+    fn set_write_data(&self, data: &[u32]);
 
-    /// Kick off a smart program execution.
-    fn trigger(&self, opcode: u32, offset: usize) -> ReturnCode;
+    /// Kick off a smart program execution on the specified `Bank` using the data
+    /// configured via `set_transaction`.
+    fn trigger(&self, opcode: u32, bank: Bank);
 }

--- a/kernel/h1/src/hil/flash/hardware.rs
+++ b/kernel/h1/src/hil/flash/hardware.rs
@@ -30,12 +30,12 @@ pub trait Hardware {
     /// Set flash transaction parameters (word offset and size). The word offset
     /// is relative to the start of flash and the size is one less than the
     /// number of words to copy.
-    fn set_transaction(&self, offset: usize, size: usize);
+    fn set_transaction(&self, offset: usize, size: usize) -> ReturnCode;
 
     /// Fill the flash controller's write buffer. data must have a length no
     /// larger than 32.
-    fn set_write_data(&self, data: &[u32]);
+    fn set_write_data(&self, data: &[u32]) -> ReturnCode;
 
     /// Kick off a smart program execution.
-    fn trigger(&self, opcode: u32);
+    fn trigger(&self, opcode: u32, offset: usize) -> ReturnCode;
 }

--- a/kernel/h1/src/hil/flash/mod.rs
+++ b/kernel/h1/src/hil/flash/mod.rs
@@ -33,6 +33,7 @@ pub type FlashImpl<'h, A> = self::driver::FlashImpl<'h, A, self::fake::FakeHw>;
 pub type FlashImpl<'h, A> = self::driver::FlashImpl<'static, A, self::h1_hw::H1bHw>;
 
 pub use self::flash::{Client,Flash};
+pub use self::hardware::Bank;
 pub use self::hardware::Hardware;
 
 // Constants used by multiple submodules.

--- a/kernel/h1/src/hil/flash/smart_program.rs
+++ b/kernel/h1/src/hil/flash/smart_program.rs
@@ -43,11 +43,11 @@ impl SmartProgramState {
     /// Performs a state machine update during smart programming. This should be
     /// done during initialization and when a wait finishes.
     pub fn step<'a, A: Alarm<'a>, H: super::hardware::Hardware>(
-        self, alarm: &A, hw: &H, opcode: u32, offset: usize) -> Self
+        self, alarm: &A, hw: &H, opcode: u32, bank: super::hardware::Bank) -> Self
     {
         match self {
             Init(attempts_remaining, final_pulse_needed, timeout_nanoseconds) => {
-                hw.trigger(opcode, offset);
+                hw.trigger(opcode, bank);
                 set_program_timeout(alarm, timeout_nanoseconds);
                 Running(attempts_remaining - 1, final_pulse_needed, timeout_nanoseconds)
             },
@@ -65,7 +65,7 @@ impl SmartProgramState {
                     // If final_pulse_needed, trigger one last smart programming
                     // cycle. Otherwise indicate success.
                     if final_pulse_needed {
-                        hw.trigger(opcode, offset);
+                        hw.trigger(opcode, bank);
                         set_program_timeout(alarm, timeout_nanoseconds);
                         return Running(0, false, timeout_nanoseconds);
                     }
@@ -78,7 +78,7 @@ impl SmartProgramState {
                 // limit.
                 if attempts_remaining > 0 {
                     // Operation failed; retry.
-                    hw.trigger(opcode, offset);
+                    hw.trigger(opcode, bank);
                     set_program_timeout(alarm, timeout_nanoseconds);
                     return SmartProgramState::Running(attempts_remaining - 1,
                         final_pulse_needed, timeout_nanoseconds);

--- a/kernel/h1/src/hil/flash/smart_program.rs
+++ b/kernel/h1/src/hil/flash/smart_program.rs
@@ -43,11 +43,11 @@ impl SmartProgramState {
     /// Performs a state machine update during smart programming. This should be
     /// done during initialization and when a wait finishes.
     pub fn step<'a, A: Alarm<'a>, H: super::hardware::Hardware>(
-        self, alarm: &A, hw: &H, opcode: u32) -> Self
+        self, alarm: &A, hw: &H, opcode: u32, offset: usize) -> Self
     {
         match self {
             Init(attempts_remaining, final_pulse_needed, timeout_nanoseconds) => {
-                hw.trigger(opcode);
+                hw.trigger(opcode, offset);
                 set_program_timeout(alarm, timeout_nanoseconds);
                 Running(attempts_remaining - 1, final_pulse_needed, timeout_nanoseconds)
             },
@@ -65,7 +65,7 @@ impl SmartProgramState {
                     // If final_pulse_needed, trigger one last smart programming
                     // cycle. Otherwise indicate success.
                     if final_pulse_needed {
-                        hw.trigger(opcode);
+                        hw.trigger(opcode, offset);
                         set_program_timeout(alarm, timeout_nanoseconds);
                         return Running(0, false, timeout_nanoseconds);
                     }
@@ -78,7 +78,7 @@ impl SmartProgramState {
                 // limit.
                 if attempts_remaining > 0 {
                     // Operation failed; retry.
-                    hw.trigger(opcode);
+                    hw.trigger(opcode, offset);
                     set_program_timeout(alarm, timeout_nanoseconds);
                     return SmartProgramState::Running(attempts_remaining - 1,
                         final_pulse_needed, timeout_nanoseconds);

--- a/userspace/flash_test/src/fake.rs
+++ b/userspace/flash_test/src/fake.rs
@@ -15,6 +15,8 @@
 use h1::hil::flash::Bank;
 use kernel::ReturnCode;
 
+const WORDS_PER_BANK: usize = 0x10000;
+
 /// Works the fake through a series of writes and erases to test its
 /// functionality. Simulates both failed operations and successful operations.
 #[test]
@@ -28,10 +30,36 @@ fn fake_hw() -> bool {
     require!(fake.read(1023) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
     require!(fake.read(1300) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
     require!(fake.read(1301) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
+    require!(fake.read(WORDS_PER_BANK + 512) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
+    require!(fake.read(WORDS_PER_BANK + 1023) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
+    require!(fake.read(WORDS_PER_BANK + 1300) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
+    require!(fake.read(WORDS_PER_BANK + 1301) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
 
-    // Operation 1: successful write to two words.
+    // Operation 1a: successful write to two words in bank 0.
     fake.set_transaction(1300, 2 - 1);
     fake.set_write_data(&[0xFFFF0FFF, 0xFFFAFFFF]);
+    fake.trigger(h1::hil::flash::driver::WRITE_OPCODE, Bank::Zero);
+    require!(fake.is_programming() == true);
+    fake.inject_result(0);
+    require!(fake.is_programming() == false);
+    require!(fake.read_error() == 0);
+    fake.trigger(h1::hil::flash::driver::WRITE_OPCODE, Bank::Zero);
+    require!(fake.is_programming() == true);
+    fake.finish_operation();
+    require!(fake.read_error() == 0);
+    require!(fake.is_programming() == false);
+    require!(fake.read(512) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
+    require!(fake.read(1023) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
+    require!(fake.read(1300) == ReturnCode::SuccessWithValue { value: 0xFFFF0FFF });
+    require!(fake.read(1301) == ReturnCode::SuccessWithValue { value: 0xFFFAFFFF });
+    require!(fake.read(WORDS_PER_BANK + 512) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
+    require!(fake.read(WORDS_PER_BANK + 1023) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
+    require!(fake.read(WORDS_PER_BANK + 1300) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
+    require!(fake.read(WORDS_PER_BANK + 1301) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
+
+    // Operation 1b: successful write to two words in bank 1.
+    fake.set_transaction(1300, 2 - 1);
+    fake.set_write_data(&[0xFFFF1FFF, 0xFFFBFFFF]);
     fake.trigger(h1::hil::flash::driver::WRITE_OPCODE, Bank::One);
     require!(fake.is_programming() == true);
     fake.inject_result(0);
@@ -46,11 +74,15 @@ fn fake_hw() -> bool {
     require!(fake.read(1023) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
     require!(fake.read(1300) == ReturnCode::SuccessWithValue { value: 0xFFFF0FFF });
     require!(fake.read(1301) == ReturnCode::SuccessWithValue { value: 0xFFFAFFFF });
+    require!(fake.read(WORDS_PER_BANK + 512) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
+    require!(fake.read(WORDS_PER_BANK + 1023) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
+    require!(fake.read(WORDS_PER_BANK + 1300) == ReturnCode::SuccessWithValue { value: 0xFFFF1FFF });
+    require!(fake.read(WORDS_PER_BANK + 1301) == ReturnCode::SuccessWithValue { value: 0xFFFBFFFF });
 
     // Operation 2: failed write. Verifies the write doesn't change anything.
     fake.set_transaction(1300, 2 - 1);
     fake.set_write_data(&[0xFFFF00FF, 0xFFAAFFFF]);
-    fake.trigger(h1::hil::flash::driver::WRITE_OPCODE, Bank::One);
+    fake.trigger(h1::hil::flash::driver::WRITE_OPCODE, Bank::Zero);
     require!(fake.is_programming() == true);
     fake.inject_result(0x8);  // Program failed
     require!(fake.read_error() == 0x8);
@@ -64,12 +96,12 @@ fn fake_hw() -> bool {
     // overlap to the next word.
     fake.set_transaction(1300, 1 - 1);
     fake.set_write_data(&[0xFFFF00FF]);
-    fake.trigger(h1::hil::flash::driver::WRITE_OPCODE, Bank::One);
+    fake.trigger(h1::hil::flash::driver::WRITE_OPCODE, Bank::Zero);
     require!(fake.is_programming() == true);
     fake.inject_result(0);
     require!(fake.is_programming() == false);
     require!(fake.read_error() == 0);
-    fake.trigger(h1::hil::flash::driver::WRITE_OPCODE, Bank::One);
+    fake.trigger(h1::hil::flash::driver::WRITE_OPCODE, Bank::Zero);
     require!(fake.is_programming() == true);
     fake.finish_operation();
     require!(fake.read_error() == 0);
@@ -79,8 +111,26 @@ fn fake_hw() -> bool {
     require!(fake.read(1300) == ReturnCode::SuccessWithValue { value: 0xFFFF00FF });
     require!(fake.read(1301) == ReturnCode::SuccessWithValue { value: 0xFFFAFFFF });
 
-    // Operation 4: successful erase of the second page. Confirms the erase
-    // does not affect the third page.
+    // Operation 4a: successful erase of the second page in bank 0.
+    // Confirms the erase does not affect the third page.
+    fake.set_transaction(512, 0);
+    require!(fake.is_programming() == false);
+    fake.trigger(h1::hil::flash::driver::ERASE_OPCODE, Bank::Zero);
+    require!(fake.is_programming() == true);
+    fake.finish_operation();
+    require!(fake.read_error() == 0);
+    require!(fake.is_programming() == false);
+    require!(fake.read(512) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
+    require!(fake.read(1023) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
+    require!(fake.read(1300) == ReturnCode::SuccessWithValue { value: 0xFFFF00FF });
+    require!(fake.read(1301) == ReturnCode::SuccessWithValue { value: 0xFFFAFFFF });
+    require!(fake.read(WORDS_PER_BANK + 512) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
+    require!(fake.read(WORDS_PER_BANK + 1023) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
+    require!(fake.read(WORDS_PER_BANK + 1300) == ReturnCode::SuccessWithValue { value: 0xFFFF1FFF });
+    require!(fake.read(WORDS_PER_BANK + 1301) == ReturnCode::SuccessWithValue { value: 0xFFFBFFFF });
+
+    // Operation 4b: successful erase of the second page in bank 0.
+    // Confirms the erase does not affect the third page.
     fake.set_transaction(512, 0);
     require!(fake.is_programming() == false);
     fake.trigger(h1::hil::flash::driver::ERASE_OPCODE, Bank::One);
@@ -92,9 +142,32 @@ fn fake_hw() -> bool {
     require!(fake.read(1023) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
     require!(fake.read(1300) == ReturnCode::SuccessWithValue { value: 0xFFFF00FF });
     require!(fake.read(1301) == ReturnCode::SuccessWithValue { value: 0xFFFAFFFF });
+    require!(fake.read(WORDS_PER_BANK + 512) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
+    require!(fake.read(WORDS_PER_BANK + 1023) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
+    require!(fake.read(WORDS_PER_BANK + 1300) == ReturnCode::SuccessWithValue { value: 0xFFFF1FFF });
+    require!(fake.read(WORDS_PER_BANK + 1301) == ReturnCode::SuccessWithValue { value: 0xFFFBFFFF });
 
-    // Operation 5: successful erase of the third page. Verifies the erase
-    // affects the values in the third page.
+    // Operation 5a: successful erase of the third page in bank 0.
+    // Verifies the erase affects the values in the third page but
+    // does not affect bank 1.
+    fake.set_transaction(1024, 0);
+    require!(fake.is_programming() == false);
+    fake.trigger(h1::hil::flash::driver::ERASE_OPCODE, Bank::Zero);
+    require!(fake.is_programming() == true);
+    fake.finish_operation();
+    require!(fake.read_error() == 0);
+    require!(fake.is_programming() == false);
+    require!(fake.read(512) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
+    require!(fake.read(1023) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
+    require!(fake.read(1300) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
+    require!(fake.read(1301) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
+    require!(fake.read(WORDS_PER_BANK + 512) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
+    require!(fake.read(WORDS_PER_BANK + 1023) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
+    require!(fake.read(WORDS_PER_BANK + 1300) == ReturnCode::SuccessWithValue { value: 0xFFFF1FFF });
+    require!(fake.read(WORDS_PER_BANK + 1301) == ReturnCode::SuccessWithValue { value: 0xFFFBFFFF });
+
+    // Operation 5b: successful erase of the third page in bank 0.
+    // Verifies the erase affects the values in the third page in bank 1.
     fake.set_transaction(1024, 0);
     require!(fake.is_programming() == false);
     fake.trigger(h1::hil::flash::driver::ERASE_OPCODE, Bank::One);
@@ -106,13 +179,17 @@ fn fake_hw() -> bool {
     require!(fake.read(1023) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
     require!(fake.read(1300) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
     require!(fake.read(1301) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
+    require!(fake.read(WORDS_PER_BANK + 512) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
+    require!(fake.read(WORDS_PER_BANK + 1023) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
+    require!(fake.read(WORDS_PER_BANK + 1300) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
+    require!(fake.read(WORDS_PER_BANK + 1301) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
 
     // At this point, the fake flash module's log is full. Attempting another
     // operation should result in a flash error even if the operation is
     // otherwise valid.
     fake.set_transaction(1300, 1 - 1);
     fake.set_write_data(&[0xABCDC0FF]);
-    fake.trigger(h1::hil::flash::driver::WRITE_OPCODE, Bank::One);
+    fake.trigger(h1::hil::flash::driver::WRITE_OPCODE, Bank::Zero);
     require!(fake.is_programming() == true);
     fake.finish_operation();
     require!(fake.read_error() == 0x8);
@@ -135,12 +212,12 @@ fn write_set_bit() -> bool {
     // Operation 1: successful write.
     fake.set_transaction(1300, 1 - 1);
     fake.set_write_data(&[0xFFFF0FFF]);
-    fake.trigger(h1::hil::flash::driver::WRITE_OPCODE, Bank::One);
+    fake.trigger(h1::hil::flash::driver::WRITE_OPCODE, Bank::Zero);
     require!(fake.is_programming() == true);
     fake.inject_result(0);
     require!(fake.is_programming() == false);
     require!(fake.read_error() == 0);
-    fake.trigger(h1::hil::flash::driver::WRITE_OPCODE, Bank::One);
+    fake.trigger(h1::hil::flash::driver::WRITE_OPCODE, Bank::Zero);
     require!(fake.is_programming() == true);
     fake.finish_operation();
     require!(fake.read_error() == 0);
@@ -152,12 +229,12 @@ fn write_set_bit() -> bool {
     // Operation 2: failed write. Verifies the write doesn't change anything.
     fake.set_transaction(1300, 1 - 1);
     fake.set_write_data(&[0x0000F000]);
-    fake.trigger(h1::hil::flash::driver::WRITE_OPCODE, Bank::One);
+    fake.trigger(h1::hil::flash::driver::WRITE_OPCODE, Bank::Zero);
     require!(fake.is_programming() == true);
     fake.inject_result(0);
     require!(fake.is_programming() == false);
     require!(fake.read_error() == 0);
-    fake.trigger(h1::hil::flash::driver::WRITE_OPCODE, Bank::One);
+    fake.trigger(h1::hil::flash::driver::WRITE_OPCODE, Bank::Zero);
     require!(fake.is_programming() == true);
     fake.finish_operation();
     require!(fake.read_error() == 0x8);

--- a/userspace/flash_test/src/fake.rs
+++ b/userspace/flash_test/src/fake.rs
@@ -31,12 +31,12 @@ fn fake_hw() -> bool {
     // Operation 1: successful write to two words.
     fake.set_transaction(1300, 2 - 1);
     fake.set_write_data(&[0xFFFF0FFF, 0xFFFAFFFF]);
-    fake.trigger(h1::hil::flash::driver::WRITE_OPCODE);
+    fake.trigger(h1::hil::flash::driver::WRITE_OPCODE, 1300);
     require!(fake.is_programming() == true);
     fake.inject_result(0);
     require!(fake.is_programming() == false);
     require!(fake.read_error() == 0);
-    fake.trigger(h1::hil::flash::driver::WRITE_OPCODE);
+    fake.trigger(h1::hil::flash::driver::WRITE_OPCODE, 1300);
     require!(fake.is_programming() == true);
     fake.finish_operation();
     require!(fake.read_error() == 0);
@@ -49,7 +49,7 @@ fn fake_hw() -> bool {
     // Operation 2: failed write. Verifies the write doesn't change anything.
     fake.set_transaction(1300, 2 - 1);
     fake.set_write_data(&[0xFFFF00FF, 0xFFAAFFFF]);
-    fake.trigger(h1::hil::flash::driver::WRITE_OPCODE);
+    fake.trigger(h1::hil::flash::driver::WRITE_OPCODE, 1300);
     require!(fake.is_programming() == true);
     fake.inject_result(0x8);  // Program failed
     require!(fake.read_error() == 0x8);
@@ -63,12 +63,12 @@ fn fake_hw() -> bool {
     // overlap to the next word.
     fake.set_transaction(1300, 1 - 1);
     fake.set_write_data(&[0xFFFF00FF]);
-    fake.trigger(h1::hil::flash::driver::WRITE_OPCODE);
+    fake.trigger(h1::hil::flash::driver::WRITE_OPCODE, 1300);
     require!(fake.is_programming() == true);
     fake.inject_result(0);
     require!(fake.is_programming() == false);
     require!(fake.read_error() == 0);
-    fake.trigger(h1::hil::flash::driver::WRITE_OPCODE);
+    fake.trigger(h1::hil::flash::driver::WRITE_OPCODE, 1300);
     require!(fake.is_programming() == true);
     fake.finish_operation();
     require!(fake.read_error() == 0);
@@ -82,7 +82,7 @@ fn fake_hw() -> bool {
     // does not affect the third page.
     fake.set_transaction(512, 0);
     require!(fake.is_programming() == false);
-    fake.trigger(h1::hil::flash::driver::ERASE_OPCODE);
+    fake.trigger(h1::hil::flash::driver::ERASE_OPCODE, 512);
     require!(fake.is_programming() == true);
     fake.finish_operation();
     require!(fake.read_error() == 0);
@@ -96,7 +96,7 @@ fn fake_hw() -> bool {
     // affects the values in the third page.
     fake.set_transaction(1024, 0);
     require!(fake.is_programming() == false);
-    fake.trigger(h1::hil::flash::driver::ERASE_OPCODE);
+    fake.trigger(h1::hil::flash::driver::ERASE_OPCODE, 1024);
     require!(fake.is_programming() == true);
     fake.finish_operation();
     require!(fake.read_error() == 0);
@@ -111,7 +111,7 @@ fn fake_hw() -> bool {
     // otherwise valid.
     fake.set_transaction(1300, 1 - 1);
     fake.set_write_data(&[0xABCDC0FF]);
-    fake.trigger(h1::hil::flash::driver::WRITE_OPCODE);
+    fake.trigger(h1::hil::flash::driver::WRITE_OPCODE, 1300);
     require!(fake.is_programming() == true);
     fake.finish_operation();
     require!(fake.read_error() == 0x8);
@@ -134,12 +134,12 @@ fn write_set_bit() -> bool {
     // Operation 1: successful write.
     fake.set_transaction(1300, 1 - 1);
     fake.set_write_data(&[0xFFFF0FFF]);
-    fake.trigger(h1::hil::flash::driver::WRITE_OPCODE);
+    fake.trigger(h1::hil::flash::driver::WRITE_OPCODE, 1300);
     require!(fake.is_programming() == true);
     fake.inject_result(0);
     require!(fake.is_programming() == false);
     require!(fake.read_error() == 0);
-    fake.trigger(h1::hil::flash::driver::WRITE_OPCODE);
+    fake.trigger(h1::hil::flash::driver::WRITE_OPCODE, 1300);
     require!(fake.is_programming() == true);
     fake.finish_operation();
     require!(fake.read_error() == 0);
@@ -151,12 +151,12 @@ fn write_set_bit() -> bool {
     // Operation 2: failed write. Verifies the write doesn't change anything.
     fake.set_transaction(1300, 1 - 1);
     fake.set_write_data(&[0x0000F000]);
-    fake.trigger(h1::hil::flash::driver::WRITE_OPCODE);
+    fake.trigger(h1::hil::flash::driver::WRITE_OPCODE, 1300);
     require!(fake.is_programming() == true);
     fake.inject_result(0);
     require!(fake.is_programming() == false);
     require!(fake.read_error() == 0);
-    fake.trigger(h1::hil::flash::driver::WRITE_OPCODE);
+    fake.trigger(h1::hil::flash::driver::WRITE_OPCODE, 1300);
     require!(fake.is_programming() == true);
     fake.finish_operation();
     require!(fake.read_error() == 0x8);

--- a/userspace/flash_test/src/fake.rs
+++ b/userspace/flash_test/src/fake.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use h1::hil::flash::Bank;
 use kernel::ReturnCode;
 
 /// Works the fake through a series of writes and erases to test its
@@ -31,12 +32,12 @@ fn fake_hw() -> bool {
     // Operation 1: successful write to two words.
     fake.set_transaction(1300, 2 - 1);
     fake.set_write_data(&[0xFFFF0FFF, 0xFFFAFFFF]);
-    fake.trigger(h1::hil::flash::driver::WRITE_OPCODE, 1300);
+    fake.trigger(h1::hil::flash::driver::WRITE_OPCODE, Bank::One);
     require!(fake.is_programming() == true);
     fake.inject_result(0);
     require!(fake.is_programming() == false);
     require!(fake.read_error() == 0);
-    fake.trigger(h1::hil::flash::driver::WRITE_OPCODE, 1300);
+    fake.trigger(h1::hil::flash::driver::WRITE_OPCODE, Bank::One);
     require!(fake.is_programming() == true);
     fake.finish_operation();
     require!(fake.read_error() == 0);
@@ -49,7 +50,7 @@ fn fake_hw() -> bool {
     // Operation 2: failed write. Verifies the write doesn't change anything.
     fake.set_transaction(1300, 2 - 1);
     fake.set_write_data(&[0xFFFF00FF, 0xFFAAFFFF]);
-    fake.trigger(h1::hil::flash::driver::WRITE_OPCODE, 1300);
+    fake.trigger(h1::hil::flash::driver::WRITE_OPCODE, Bank::One);
     require!(fake.is_programming() == true);
     fake.inject_result(0x8);  // Program failed
     require!(fake.read_error() == 0x8);
@@ -63,12 +64,12 @@ fn fake_hw() -> bool {
     // overlap to the next word.
     fake.set_transaction(1300, 1 - 1);
     fake.set_write_data(&[0xFFFF00FF]);
-    fake.trigger(h1::hil::flash::driver::WRITE_OPCODE, 1300);
+    fake.trigger(h1::hil::flash::driver::WRITE_OPCODE, Bank::One);
     require!(fake.is_programming() == true);
     fake.inject_result(0);
     require!(fake.is_programming() == false);
     require!(fake.read_error() == 0);
-    fake.trigger(h1::hil::flash::driver::WRITE_OPCODE, 1300);
+    fake.trigger(h1::hil::flash::driver::WRITE_OPCODE, Bank::One);
     require!(fake.is_programming() == true);
     fake.finish_operation();
     require!(fake.read_error() == 0);
@@ -82,7 +83,7 @@ fn fake_hw() -> bool {
     // does not affect the third page.
     fake.set_transaction(512, 0);
     require!(fake.is_programming() == false);
-    fake.trigger(h1::hil::flash::driver::ERASE_OPCODE, 512);
+    fake.trigger(h1::hil::flash::driver::ERASE_OPCODE, Bank::One);
     require!(fake.is_programming() == true);
     fake.finish_operation();
     require!(fake.read_error() == 0);
@@ -96,7 +97,7 @@ fn fake_hw() -> bool {
     // affects the values in the third page.
     fake.set_transaction(1024, 0);
     require!(fake.is_programming() == false);
-    fake.trigger(h1::hil::flash::driver::ERASE_OPCODE, 1024);
+    fake.trigger(h1::hil::flash::driver::ERASE_OPCODE, Bank::One);
     require!(fake.is_programming() == true);
     fake.finish_operation();
     require!(fake.read_error() == 0);
@@ -111,7 +112,7 @@ fn fake_hw() -> bool {
     // otherwise valid.
     fake.set_transaction(1300, 1 - 1);
     fake.set_write_data(&[0xABCDC0FF]);
-    fake.trigger(h1::hil::flash::driver::WRITE_OPCODE, 1300);
+    fake.trigger(h1::hil::flash::driver::WRITE_OPCODE, Bank::One);
     require!(fake.is_programming() == true);
     fake.finish_operation();
     require!(fake.read_error() == 0x8);
@@ -134,12 +135,12 @@ fn write_set_bit() -> bool {
     // Operation 1: successful write.
     fake.set_transaction(1300, 1 - 1);
     fake.set_write_data(&[0xFFFF0FFF]);
-    fake.trigger(h1::hil::flash::driver::WRITE_OPCODE, 1300);
+    fake.trigger(h1::hil::flash::driver::WRITE_OPCODE, Bank::One);
     require!(fake.is_programming() == true);
     fake.inject_result(0);
     require!(fake.is_programming() == false);
     require!(fake.read_error() == 0);
-    fake.trigger(h1::hil::flash::driver::WRITE_OPCODE, 1300);
+    fake.trigger(h1::hil::flash::driver::WRITE_OPCODE, Bank::One);
     require!(fake.is_programming() == true);
     fake.finish_operation();
     require!(fake.read_error() == 0);
@@ -151,12 +152,12 @@ fn write_set_bit() -> bool {
     // Operation 2: failed write. Verifies the write doesn't change anything.
     fake.set_transaction(1300, 1 - 1);
     fake.set_write_data(&[0x0000F000]);
-    fake.trigger(h1::hil::flash::driver::WRITE_OPCODE, 1300);
+    fake.trigger(h1::hil::flash::driver::WRITE_OPCODE, Bank::One);
     require!(fake.is_programming() == true);
     fake.inject_result(0);
     require!(fake.is_programming() == false);
     require!(fake.read_error() == 0);
-    fake.trigger(h1::hil::flash::driver::WRITE_OPCODE, 1300);
+    fake.trigger(h1::hil::flash::driver::WRITE_OPCODE, Bank::One);
     require!(fake.is_programming() == true);
     fake.finish_operation();
     require!(fake.read_error() == 0x8);

--- a/userspace/flash_test/src/smart_program.rs
+++ b/userspace/flash_test/src/smart_program.rs
@@ -48,7 +48,7 @@ fn successful_program() -> bool {
 
     // First attempt.
     let mut state = smart_program::SmartProgramState::init(8, true, 100_000_000);
-    state = state.step(&alarm, &hw, WRITE_OPCODE);
+    state = state.step(&alarm, &hw, WRITE_OPCODE, 1300);
     require!(alarm.get_alarm() == alarm.now() + <MockAlarm as Time>::Frequency::frequency()/10);
     require!(hw.is_programming() == true);
     require!(state.return_code() == None);
@@ -56,13 +56,13 @@ fn successful_program() -> bool {
     // Finish.
     alarm.set_time(<MockAlarm as Time>::Frequency::frequency()/10);
     hw.inject_result(0);
-    state = state.step(&alarm, &hw, WRITE_OPCODE);
+    state = state.step(&alarm, &hw, WRITE_OPCODE, 1300);
     require!(alarm.get_alarm() == <MockAlarm as Time>::Frequency::frequency()/5);
     require!(hw.is_programming() == true);
     require!(state.return_code() == None);
     alarm.set_time(<MockAlarm as Time>::Frequency::frequency()/5);
     hw.finish_operation();
-    state = state.step(&alarm, &hw, WRITE_OPCODE);
+    state = state.step(&alarm, &hw, WRITE_OPCODE, 1300);
     require!(alarm.get_alarm() == 0);
     require!(hw.is_programming() == false);
     require!(state.return_code() == Some(kernel::ReturnCode::SUCCESS));
@@ -78,7 +78,7 @@ fn retries() -> bool {
 
     // First programming attempt.
     let mut state = smart_program::SmartProgramState::init(8, true, 100_000_000);
-    state = state.step(&alarm, &hw, WRITE_OPCODE);
+    state = state.step(&alarm, &hw, WRITE_OPCODE, 1300);
     require!(alarm.get_alarm() == alarm.now() + <MockAlarm as Time>::Frequency::frequency()/10);
     require!(hw.is_programming() == true);
     require!(state.return_code() == None);
@@ -86,7 +86,7 @@ fn retries() -> bool {
     hw.inject_result(0b100);
 
     // Second attempt.
-    state = state.step(&alarm, &hw, WRITE_OPCODE);
+    state = state.step(&alarm, &hw, WRITE_OPCODE, 1300);
     require!(alarm.get_alarm() == alarm.now() + <MockAlarm as Time>::Frequency::frequency()/10);
     require!(hw.is_programming() == true);
     require!(state.return_code() == None);
@@ -94,13 +94,13 @@ fn retries() -> bool {
     hw.inject_result(0);
 
     // Finish.
-    state = state.step(&alarm, &hw, WRITE_OPCODE);
+    state = state.step(&alarm, &hw, WRITE_OPCODE, 1300);
     require!(alarm.get_alarm() == 3*<MockAlarm as Time>::Frequency::frequency()/10);
     require!(hw.is_programming() == true);
     require!(state.return_code() == None);
     alarm.set_time(3*<MockAlarm as Time>::Frequency::frequency()/10);
     hw.finish_operation();
-    state = state.step(&alarm, &hw, WRITE_OPCODE);
+    state = state.step(&alarm, &hw, WRITE_OPCODE, 1300);
     require!(alarm.get_alarm() == 0);
     require!(hw.is_programming() == false);
     require!(state.return_code() == Some(kernel::ReturnCode::SUCCESS));
@@ -118,7 +118,7 @@ fn failed() -> bool {
 
     for i in 0..8 {
         alarm.set_time(i * <MockAlarm as Time>::Frequency::frequency()/10);
-        state = state.step(&alarm, &hw, WRITE_OPCODE);
+        state = state.step(&alarm, &hw, WRITE_OPCODE, 1300);
         require!(alarm.get_alarm() ==
                  alarm.now() + <MockAlarm as Time>::Frequency::frequency()/10);
         require!(hw.is_programming() == true);
@@ -127,7 +127,7 @@ fn failed() -> bool {
     }
 
     // Finish.
-    state = state.step(&alarm, &hw, WRITE_OPCODE);
+    state = state.step(&alarm, &hw, WRITE_OPCODE, 1300);
     require!(alarm.get_alarm() == 0);
     require!(hw.is_programming() == false);
     require!(state.return_code() == Some(kernel::ReturnCode::FAIL));
@@ -143,14 +143,14 @@ fn timeout() -> bool {
 
     // First programming attempt.
     let mut state = smart_program::SmartProgramState::init(8, true, 100_000_000);
-    state = state.step(&alarm, &hw, WRITE_OPCODE);
+    state = state.step(&alarm, &hw, WRITE_OPCODE, 1300);
     require!(alarm.get_alarm() == alarm.now() + <MockAlarm as Time>::Frequency::frequency()/10);
     require!(hw.is_programming() == true);
     require!(state.return_code() == None);
 
     // Alarm trigger.
     alarm.set_time(<MockAlarm as Time>::Frequency::frequency()/10);
-    state = state.step(&alarm, &hw, WRITE_OPCODE);
+    state = state.step(&alarm, &hw, WRITE_OPCODE, 1300);
     require!(alarm.get_alarm() == 0);
     require!(state.return_code() == Some(kernel::ReturnCode::FAIL));
     true

--- a/userspace/flash_test/src/smart_program.rs
+++ b/userspace/flash_test/src/smart_program.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use h1::hil::flash::driver::WRITE_OPCODE;
-use h1::hil::flash::{Hardware,smart_program};
+use h1::hil::flash::{Bank,Hardware,smart_program};
 use kernel::hil::time::{Alarm,Frequency,Time};
 use super::mock_alarm::MockAlarm;
 use test::require;
@@ -48,7 +48,7 @@ fn successful_program() -> bool {
 
     // First attempt.
     let mut state = smart_program::SmartProgramState::init(8, true, 100_000_000);
-    state = state.step(&alarm, &hw, WRITE_OPCODE, 1300);
+    state = state.step(&alarm, &hw, WRITE_OPCODE, Bank::One);
     require!(alarm.get_alarm() == alarm.now() + <MockAlarm as Time>::Frequency::frequency()/10);
     require!(hw.is_programming() == true);
     require!(state.return_code() == None);
@@ -56,13 +56,13 @@ fn successful_program() -> bool {
     // Finish.
     alarm.set_time(<MockAlarm as Time>::Frequency::frequency()/10);
     hw.inject_result(0);
-    state = state.step(&alarm, &hw, WRITE_OPCODE, 1300);
+    state = state.step(&alarm, &hw, WRITE_OPCODE, Bank::One);
     require!(alarm.get_alarm() == <MockAlarm as Time>::Frequency::frequency()/5);
     require!(hw.is_programming() == true);
     require!(state.return_code() == None);
     alarm.set_time(<MockAlarm as Time>::Frequency::frequency()/5);
     hw.finish_operation();
-    state = state.step(&alarm, &hw, WRITE_OPCODE, 1300);
+    state = state.step(&alarm, &hw, WRITE_OPCODE, Bank::One);
     require!(alarm.get_alarm() == 0);
     require!(hw.is_programming() == false);
     require!(state.return_code() == Some(kernel::ReturnCode::SUCCESS));
@@ -78,7 +78,7 @@ fn retries() -> bool {
 
     // First programming attempt.
     let mut state = smart_program::SmartProgramState::init(8, true, 100_000_000);
-    state = state.step(&alarm, &hw, WRITE_OPCODE, 1300);
+    state = state.step(&alarm, &hw, WRITE_OPCODE, Bank::One);
     require!(alarm.get_alarm() == alarm.now() + <MockAlarm as Time>::Frequency::frequency()/10);
     require!(hw.is_programming() == true);
     require!(state.return_code() == None);
@@ -86,7 +86,7 @@ fn retries() -> bool {
     hw.inject_result(0b100);
 
     // Second attempt.
-    state = state.step(&alarm, &hw, WRITE_OPCODE, 1300);
+    state = state.step(&alarm, &hw, WRITE_OPCODE, Bank::One);
     require!(alarm.get_alarm() == alarm.now() + <MockAlarm as Time>::Frequency::frequency()/10);
     require!(hw.is_programming() == true);
     require!(state.return_code() == None);
@@ -94,13 +94,13 @@ fn retries() -> bool {
     hw.inject_result(0);
 
     // Finish.
-    state = state.step(&alarm, &hw, WRITE_OPCODE, 1300);
+    state = state.step(&alarm, &hw, WRITE_OPCODE, Bank::One);
     require!(alarm.get_alarm() == 3*<MockAlarm as Time>::Frequency::frequency()/10);
     require!(hw.is_programming() == true);
     require!(state.return_code() == None);
     alarm.set_time(3*<MockAlarm as Time>::Frequency::frequency()/10);
     hw.finish_operation();
-    state = state.step(&alarm, &hw, WRITE_OPCODE, 1300);
+    state = state.step(&alarm, &hw, WRITE_OPCODE, Bank::One);
     require!(alarm.get_alarm() == 0);
     require!(hw.is_programming() == false);
     require!(state.return_code() == Some(kernel::ReturnCode::SUCCESS));
@@ -118,7 +118,7 @@ fn failed() -> bool {
 
     for i in 0..8 {
         alarm.set_time(i * <MockAlarm as Time>::Frequency::frequency()/10);
-        state = state.step(&alarm, &hw, WRITE_OPCODE, 1300);
+        state = state.step(&alarm, &hw, WRITE_OPCODE, Bank::One);
         require!(alarm.get_alarm() ==
                  alarm.now() + <MockAlarm as Time>::Frequency::frequency()/10);
         require!(hw.is_programming() == true);
@@ -127,7 +127,7 @@ fn failed() -> bool {
     }
 
     // Finish.
-    state = state.step(&alarm, &hw, WRITE_OPCODE, 1300);
+    state = state.step(&alarm, &hw, WRITE_OPCODE, Bank::One);
     require!(alarm.get_alarm() == 0);
     require!(hw.is_programming() == false);
     require!(state.return_code() == Some(kernel::ReturnCode::FAIL));
@@ -143,14 +143,14 @@ fn timeout() -> bool {
 
     // First programming attempt.
     let mut state = smart_program::SmartProgramState::init(8, true, 100_000_000);
-    state = state.step(&alarm, &hw, WRITE_OPCODE, 1300);
+    state = state.step(&alarm, &hw, WRITE_OPCODE, Bank::One);
     require!(alarm.get_alarm() == alarm.now() + <MockAlarm as Time>::Frequency::frequency()/10);
     require!(hw.is_programming() == true);
     require!(state.return_code() == None);
 
     // Alarm trigger.
     alarm.set_time(<MockAlarm as Time>::Frequency::frequency()/10);
-    state = state.step(&alarm, &hw, WRITE_OPCODE, 1300);
+    state = state.step(&alarm, &hw, WRITE_OPCODE, Bank::One);
     require!(alarm.get_alarm() == 0);
     require!(state.return_code() == Some(kernel::ReturnCode::FAIL));
     true


### PR DESCRIPTION
This change adds support to the H1 flash driver for both flash banks.
In order to be able to use the existing interface / design, we now
need to pass the target address to both `H1bHw.set_transaction()` and
`H1bHw.trigger()`.

Further, this change adds `ReturnCode`s to the `Hardware` trait in
preparation to handle these in the driver code in a subsequent
commit.