### PR TITLE
userspace: Generate gitlongtag without trailing newline.

### DIFF
--- a/userspace/Build.mk
+++ b/userspace/Build.mk
@@ -66,7 +66,8 @@ userspace/localtests: $(addsuffix /localtests,$(BUILD_SUBDIRS))
 .PHONY: build/gitlongtag
 build/gitlongtag:
 	mkdir -p build
-	git describe --always --dirty --long >$@
+	# Remove the trailing newline character
+	printf '%s' $$(git describe --always --dirty --long) >$@
 
 include $(addsuffix /Build.mk,$(BUILD_SUBDIRS))
 


### PR DESCRIPTION
This change allows apps to consume the tag without having to strip
newline characters themselves.
