### PR TITLE
otpilot: Change Mailbox address to 0x80000.

### DIFF
--- a/userspace/otpilot/src/spi_processor.rs
+++ b/userspace/otpilot/src/spi_processor.rs
@@ -50,7 +50,7 @@ pub const SPI_FLASH_SIZE: u32 = 0x4000000;
 
 // The location of the mailbox.
 // TODO(osenft): Make this configurable, possibly by reading it from the SPI flash chip.
-pub const SPI_MAILBOX_ADDRESS: u32 = 0xf00000;
+pub const SPI_MAILBOX_ADDRESS: u32 = 0x80000;
 
 // The size of the mailbox.
 const SPI_MAILBOX_SIZE: u32 = spi_device::MAX_READ_BUFFER_SIZE as u32;


### PR DESCRIPTION
This allows to use an OpenBMC flash layout that places the mailbox
just after the `u-boot-env` partition and before the kernel by
carving out 64 KiB (minimum size of a flash partition in Linux).

A standard OpenBMC flash layout would then look as follows:
```
PARTITION  - START     - END       - SIZE      - SIZE
u-boot     - 0000_0000 - 0005_FFFF - 0006_0000 -   384 KiB
u-boot-env - 0006_0000 - 0007_FFFF - 0002_0000 -   128 KiB
mailbox    - 0008_0000 - 0008_FFFF - 0001_0000 -    64 KiB
kernel     - 0009_0000 - 003B_FFFF - 0043_0000 -  4288 KiB
rofs       - 004C_0000 - 01BF_FFFF - 0174_0000 - 23808 KiB
rwfs       - 01C0_0000 - 01FF_FFFF - 0040_0000 -  4096 KiB
```

This also works well with a few other vendor-specific OpenBMC
flash layouts which have a natural gap at 0x80000.
