### PR TITLE
userspace: Enable build of both A and B images.

### DIFF
--- a/kernel/Build.mk
+++ b/kernel/Build.mk
@@ -30,7 +30,7 @@ kernel/build$(IMAGE): sandbox_setup
 .PHONY: kernel/build-signed$(IMAGE)
 kernel/build-signed$(IMAGE): kernel/build$(IMAGE)
 
-endef
+endef # KERNEL_IMAGE_TARGETS
 
 # Instantiate for IMAGE=-a and IMAGE=-b
 $(foreach IMAGE,$(IMAGES),$(eval $(KERNEL_IMAGE_TARGETS)))

--- a/kernel/Build.mk
+++ b/kernel/Build.mk
@@ -12,12 +12,31 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-.PHONY: kernel/build
-kernel/build: sandbox_setup
-	cd kernel && $(BWRAP) cargo build --release
+IMAGES=_a _b
 
-.PHONY: kernel/build-signed
-kernel/build-signed: kernel/build
+# ------------------------------------------------------------------------------
+# Macro to define targets for a specific board-app-and-image combination.
+# Arguments:
+# - $(IMAGE) [optional suffix to build A/B images]
+define KERNEL_IMAGE_TARGETS
+
+.PHONY: kernel/build$(IMAGE)
+kernel/build$(IMAGE): sandbox_setup
+	cd kernel && \
+		CARGO_TARGET_DIR="../build/kernel/cargo$(IMAGE)" \
+		RUSTFLAGS="-C link-arg=-T./layout$(IMAGE).ld" \
+		$(BWRAP) cargo build --release
+
+.PHONY: kernel/build-signed$(IMAGE)
+kernel/build-signed$(IMAGE): kernel/build$(IMAGE)
+
+endef
+
+# Instantiate for IMAGE=-a and IMAGE=-b
+$(foreach IMAGE,$(IMAGES),$(eval $(KERNEL_IMAGE_TARGETS)))
+
+# Instantiate for IMAGE=""
+$(eval $(KERNEL_IMAGE_TARGETS))
 
 .PHONY: kernel/check
 kernel/check: sandbox_setup

--- a/kernel/chip_layout_a.ld
+++ b/kernel/chip_layout_a.ld
@@ -1,0 +1,29 @@
+/* Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* Note: modifications to prog and appram should be reflected in
+   userspace/layout.ld or Rust userspace (and tests) will fail. */
+MEMORY
+{
+/* Flash RW-A (kernel + apps) */
+  rom (rx)     : ORIGIN = 0x00044400, LENGTH = 0x0002bc00
+  prog (rx)    : ORIGIN = 0x00070000, LENGTH = 0x00010000
+
+/* RAM */
+  ram (rwx)    : ORIGIN = 0x00010000, LENGTH = 0x00004000
+  appram (rwx) : ORIGIN = 0x00014000, LENGTH = 0x0000c000
+}
+
+MPU_MIN_ALIGN = 8K;

--- a/kernel/chip_layout_b.ld
+++ b/kernel/chip_layout_b.ld
@@ -1,0 +1,29 @@
+/* Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* Note: modifications to prog and appram should be reflected in
+   userspace/layout.ld or Rust userspace (and tests) will fail. */
+MEMORY
+{
+/* Flash RW-B (kernel + apps) */
+  rom (rx)     : ORIGIN = 0x00084400, LENGTH = 0x0002bc00
+  prog (rx)    : ORIGIN = 0x000b0000, LENGTH = 0x00010000
+
+/* RAM */
+  ram (rwx)    : ORIGIN = 0x00010000, LENGTH = 0x00004000
+  appram (rwx) : ORIGIN = 0x00014000, LENGTH = 0x0000c000
+}
+
+MPU_MIN_ALIGN = 8K;

--- a/kernel/layout_a.ld
+++ b/kernel/layout_a.ld
@@ -1,0 +1,17 @@
+/* Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+INCLUDE ./chip_layout_a.ld
+INCLUDE ./kernel_layout.ld

--- a/kernel/layout_b.ld
+++ b/kernel/layout_b.ld
@@ -1,0 +1,17 @@
+/* Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+INCLUDE ./chip_layout_b.ld
+INCLUDE ./kernel_layout.ld

--- a/userspace/Build.mk
+++ b/userspace/Build.mk
@@ -124,7 +124,7 @@ build/userspace/$(APP)/$(BOARD)/full_image$(IMAGE): \
 	cat $(TANGO_BOOTLOADER$(IMAGE)) build/userspace/$(APP)/$(BOARD)/signed_image$(IMAGE) \
 		> build/userspace/$(APP)/$(BOARD)/full_image$(IMAGE);
 
-endef
+endef # IMAGE_TARGETS
 
 
 # ------------------------------------------------------------------------------
@@ -174,7 +174,7 @@ userspace/$(APP)/$(BOARD)/run: \
 		stty -F /dev/ttyUltraTarget2 115200 -icrnl ; \
 		build/cargo-host/release/runner'
 
-endef
+endef # C_APP_BOARD_TARGETS
 
 # C_APP_TARGET contains build rules that are specific to a C app but not an
 # (APP, BOARD) combination.
@@ -188,7 +188,7 @@ build/userspace/$(APP)/cortex-m3/cortex-m3.tbf: \
 		build/cargo-host/release/elf2tab
 	+flock build/libtock_c_lock $(BWRAP) $(MAKE) -C userspace/$(APP) -f TockMakefile
 
-endef
+endef # C_APP_TARGETS
 
 # ------------------------------------------------------------------------------
 # Generate the targets for all board-and-app combinations.
@@ -234,7 +234,7 @@ userspace/$(APP)/localtests: \
 		$(if $(filter $(APP),$(C_APPS)),$(foreach BOARD,$(BOARDS),userspace/$(APP)/$(BOARD)/localtests)) \
 		$(foreach BOARD,$(BOARDS),$(if $(filter $(APP),$(C_APPS_$(BOARD))),userspace/$(APP)/$(BOARD)/localtests))
 
-endef
+endef # C_APP_COMBINED_TARGET
 
 # ------------------------------------------------------------------------------
 # Generate the targets for all apps combinations.
@@ -271,7 +271,7 @@ userspace/$(APP)/$(BOARD)/doc: sandbox_setup build/gitlongtag
 .PHONY: userspace/$(APP)/$(BOARD)/localtests
 userspace/$(APP)/$(BOARD)/localtests:
 
-endef
+endef # RUST_APP_BOARD_TARGETS
 
 # ------------------------------------------------------------------------------
 # Macro to define targets for a specific board-app-and-image combination.
@@ -337,7 +337,7 @@ build/userspace/$(APP)/$(BOARD)/app$(IMAGE).tbf: \
 		     false ; \
 		fi
 
-endef
+endef # RUST_APP_BOARD_IMAGE_TARGETS
 
 # ------------------------------------------------------------------------------
 # Generate the targets for all board-and-app combinations.
@@ -385,7 +385,7 @@ userspace/$(APP)/localtests: \
 		$(if $(filter $(APP),$(RUST_APPS)),$(foreach BOARD,$(BOARDS),userspace/$(APP)/$(BOARD)/localtests)) \
 		$(foreach BOARD,$(BOARDS),$(if $(filter $(APP),$(RUST_APPS_$(BOARD))),userspace/$(APP)/$(BOARD)/localtests))
 
-endef
+endef # RUST_APP_TARGET
 
 # ------------------------------------------------------------------------------
 # Generate the targets for all apps combinations.
@@ -482,7 +482,7 @@ build/userspace/$(APP)/$(BOARD)/app.tbf: \
 		     false ; \
 		fi
 
-endef
+endef # RUST_TEST_BOARD_TARGETS
 
 # ------------------------------------------------------------------------------
 # Generate the targets for all board-and-app combinations.
@@ -527,7 +527,7 @@ userspace/$(APP)/localtests: \
 		$(if $(filter $(APP),$(RUST_TESTS)),$(foreach BOARD,$(BOARDS),userspace/$(APP)/$(BOARD)/localtests)) \
 		$(foreach BOARD,$(BOARDS),$(if $(filter $(APP),$(RUST_TESTS_$(BOARD))),userspace/$(APP)/$(BOARD)/localtests))
 
-endef
+endef # RUST_TEST_TARGET
 
 # ------------------------------------------------------------------------------
 # Generate the targets for all apps combinations.

--- a/userspace/layout_a.ld
+++ b/userspace/layout_a.ld
@@ -1,0 +1,30 @@
+/* Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* Note: modifications should be reflected in chip_layout.ld or Rust
+   userspace (and tests) will fail. */
+
+MEMORY {
+/* Flash RW-A (apps) */
+  FLASH (rx) : ORIGIN = 0x00070040, LENGTH = 0x0000FFC0
+
+/* */
+  SRAM (rwx) : ORIGIN = 0x00014000, LENGTH = 0x0000c000
+}
+
+MPU_MIN_ALIGN = 8K;
+STACK_SIZE = 2048;
+
+INCLUDE ../third_party/libtock-rs/layout.ld

--- a/userspace/layout_b.ld
+++ b/userspace/layout_b.ld
@@ -1,0 +1,30 @@
+/* Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* Note: modifications should be reflected in chip_layout.ld or Rust
+   userspace (and tests) will fail. */
+
+MEMORY {
+/* Flash RW-B (apps) */
+  FLASH (rx) : ORIGIN = 0x000b0040, LENGTH = 0x0000FFC0
+
+/* */
+  SRAM (rwx) : ORIGIN = 0x00014000, LENGTH = 0x0000c000
+}
+
+MPU_MIN_ALIGN = 8K;
+STACK_SIZE = 2048;
+
+INCLUDE ../third_party/libtock-rs/layout.ld

--- a/userspace/otpilot/Build.mk
+++ b/userspace/otpilot/Build.mk
@@ -15,3 +15,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 RUST_APPS_papa += otpilot
+
+# Enable support to build app for multiple images.
+RUST_IMAGES_otpilot = $(IMAGES)


### PR DESCRIPTION
This change adds the option for Rust userspace apps to be built with
both and A and a B image with different address offsets.

It also enables this functionality for the otpilot app.
