### PR TITLE
spiutils: Remove "Unknown" values from wire_enums.

### DIFF
--- a/shared-lib/spiutils/src/protocol/error.rs
+++ b/shared-lib/spiutils/src/protocol/error.rs
@@ -27,9 +27,6 @@ use crate::protocol::wire::WireEnum;
 wire_enum! {
     /// The content type.
     pub enum ContentType: u8 {
-        /// Unknown message type.
-        Unknown = 0xff,
-
         /// The checksum on the message was invalid.
         BadChecksum = 0x01,
 

--- a/shared-lib/spiutils/src/protocol/firmware.rs
+++ b/shared-lib/spiutils/src/protocol/firmware.rs
@@ -31,9 +31,6 @@ use crate::protocol::wire::WireEnum;
 wire_enum! {
     /// The content type.
     pub enum ContentType: u8 {
-        /// Unknown message type.
-        Unknown = 0xff,
-
         /// Request to prepare for an update
         UpdatePrepareRequest = 0x01,
 
@@ -262,9 +259,6 @@ impl ToWire for UpdatePrepareRequest {
 wire_enum! {
     /// The result of an update prepare request.
     pub enum UpdatePrepareResult: u8 {
-        /// Unknown result type.
-        Unknown = 0xff,
-
         /// Success
         Success = 0x00,
 
@@ -371,9 +365,6 @@ impl ToWire for WriteChunkRequest<'_> {
 wire_enum! {
     /// The result of a write chunk request.
     pub enum WriteChunkResult: u8 {
-        /// Unknown result type.
-        Unknown = 0xff,
-
         /// Success
         Success = 0x00,
 

--- a/shared-lib/spiutils/src/protocol/payload.rs
+++ b/shared-lib/spiutils/src/protocol/payload.rs
@@ -74,9 +74,6 @@ pub fn compute_checksum(header: &Header, payload: &[u8]) -> u8 {
 wire_enum! {
     /// The content type.
     pub enum ContentType: u8 {
-        /// Unknown message type.
-        Unknown = 0xff,
-
         /// Error
         Error = 0x00,
 


### PR DESCRIPTION
We always want and need "known" values in these messages, so having
the "Unknwown" values is misleading.
