### PR TITLE
Upgrade Tock to a more recent version and libtock-rs to HEAD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,8 +99,8 @@ prtest: build check devicetests localtests
 # Installs the necessary Rust toolchains
 .PHONY: setup
 setup:
-	cd userspace && rustup target add thumbv7m-none-eabi && cd ..
-	cd kernel && rustup target add thumbv7m-none-eabi && cd ..
+	cd userspace && rustup target add thumbv7m-none-eabi
+	cd kernel && rustup target add thumbv7m-none-eabi
 
 
 # A target that prints an error message and fails the build if the cargo version

--- a/Makefile
+++ b/Makefile
@@ -99,14 +99,8 @@ prtest: build check devicetests localtests
 # Installs the necessary Rust toolchains
 .PHONY: setup
 setup:
-	rustup toolchain add --profile minimal \
-		"$$(cat third_party/libtock-rs/rust-toolchain)"
-	rustup toolchain add --profile minimal \
-		"$$(cat third_party/tock/rust-toolchain)"
-	rustup target add --toolchain \
-		"$$(cat third_party/libtock-rs/rust-toolchain)" thumbv7m-none-eabi
-	rustup target add --toolchain \
-		"$$(cat third_party/tock/rust-toolchain)" thumbv7m-none-eabi
+	cd userspace && rustup target add thumbv7m-none-eabi && cd ..
+	cd kernel && rustup target add thumbv7m-none-eabi && cd ..
 
 
 # A target that prints an error message and fails the build if the cargo version

--- a/kernel/h1/src/chip.rs
+++ b/kernel/h1/src/chip.rs
@@ -42,7 +42,8 @@ impl Hotel {
 impl Chip for Hotel {
     type MPU = cortexm3::mpu::MPU;
     type UserspaceKernelBoundary = cortexm3::syscall::SysCall;
-    type SysTick = cortexm3::systick::SysTick;
+    type SchedulerTimer = cortexm3::systick::SysTick;
+    type WatchDog = ();
 
     fn has_pending_interrupts(&self) -> bool {
         unsafe { cortexm3::nvic::next_pending().is_some() }
@@ -108,9 +109,11 @@ impl Chip for Hotel {
         &self.mpu
     }
 
-    fn systick(&self) -> &Self::SysTick {
+    fn scheduler_timer(&self) -> &Self::SchedulerTimer {
         &self.systick
     }
+
+    fn watchdog(&self) -> &() { &() }
 
     fn userspace_kernel_boundary(&self) -> &cortexm3::syscall::SysCall {
         &self.userspace_kernel_boundary

--- a/kernel/h1/src/hil/flash/driver.rs
+++ b/kernel/h1/src/hil/flash/driver.rs
@@ -142,7 +142,7 @@ pub const ERASE_OPCODE: u32 = 0x31415927;
 pub const WRITE_OPCODE: u32 = 0x27182818;
 
 impl<'d, A: Alarm<'d>, H: Hardware> ::kernel::hil::time::AlarmClient for FlashImpl<'d, A, H> {
-    fn fired(&self) {
+    fn alarm(&self) {
         if let Some(state) = self.smart_program_state.take() {
             let state = state.step(
                 self.alarm, self.hw, self.opcode.get(), self.write_bank.get());

--- a/kernel/h1/src/lib.rs
+++ b/kernel/h1/src/lib.rs
@@ -15,7 +15,7 @@
 #![crate_name = "h1"]
 #![crate_type = "rlib"]
 #![no_std]
-#![feature(asm, core_intrinsics, const_fn, naked_functions)]
+#![feature(llvm_asm, core_intrinsics, const_fn, naked_functions)]
 
 extern crate cortexm3;
 
@@ -58,7 +58,7 @@ unsafe extern "C" fn unhandled_interrupt() {
     let mut interrupt_number: u32;
 
     // IPSR[8:0] holds the currently active interrupt
-    asm!(
+    llvm_asm!(
         "mrs    r0, ipsr                    "
         : "={r0}"(interrupt_number)
         :

--- a/kernel/h1/src/pmu.rs
+++ b/kernel/h1/src/pmu.rs
@@ -310,8 +310,8 @@ impl reset::Reset for ResetImpl {
         // Wait for reboot; should never return
         loop {
             unsafe {
-                asm!("dsb" :::: "volatile");
-                asm!("wfi" :::: "volatile");
+                llvm_asm!("dsb" :::: "volatile");
+                llvm_asm!("wfi" :::: "volatile");
             }
         }
     }

--- a/third_party/Build.mk
+++ b/third_party/Build.mk
@@ -22,9 +22,6 @@
 
 .PHONY: third_party/build
 third_party/build: build/cargo-host/release/elf2tab sandbox_setup
-	cd third_party/libtock-rs && \
-		CARGO_TARGET_DIR="../../build/userspace/cargo" \
-		$(BWRAP) cargo build --offline --release --target=thumbv7m-none-eabi --examples
 
 .PHONY: third_party/build-signed
 third_party/build-signed: third_party/build
@@ -33,9 +30,6 @@ third_party/build-signed: third_party/build
 third_party/check: cargo_version_check sandbox_setup build/elf2tab
 	cd build/elf2tab && \
 		CARGO_TARGET_DIR="../../build/cargo-host" $(BWRAP) cargo check --release
-	cd third_party/libtock-rs && \
-		CARGO_TARGET_DIR="../../build/userspace/cargo" \
-		$(BWRAP) cargo check --offline --release --target=thumbv7m-none-eabi --examples
 	cd third_party/rustc-demangle && \
 		CARGO_TARGET_DIR="../../build/cargo-host" \
 		$(BWRAP) cargo check --offline --release
@@ -60,9 +54,6 @@ third_party/doc: cargo_version_check sandbox_setup build/elf2tab
 third_party/localtests: cargo_version_check sandbox_setup build/elf2tab
 	cd build/elf2tab && \
 		CARGO_TARGET_DIR="../../build/cargo-host" $(BWRAP) cargo test --release
-	cd third_party/libtock-rs && \
-		CARGO_TARGET_DIR="../../build/cargo-host" \
-		$(BWRAP) cargo test --lib --offline --release
 	cd third_party/rustc-demangle && \
 		CARGO_TARGET_DIR="../../build/cargo-host" \
 		$(BWRAP) cargo test --offline --release

--- a/userspace/Build.mk
+++ b/userspace/Build.mk
@@ -460,12 +460,12 @@ userspace/$(APP)/$(BOARD)/run: \
 
 .PHONY: build/userspace/$(APP)/$(BOARD)/app
 build/userspace/$(APP)/$(BOARD)/app: sandbox_setup
-	rm -f build/userspace/cargo/thumbv7m-none-eabi/release//$(APP)-*
+	rm -f build/userspace/cargo/thumbv7m-none-eabi/release/deps/$(APP)-*
 	cd userspace/$(APP) && TOCK_KERNEL_VERSION=$(APP) \
 		$(BWRAP) cargo test --no-run --offline --release
 	mkdir -p build/userspace/$(APP)/$(BOARD)
-	find build/userspace/cargo/thumbv7m-none-eabi/release/ -maxdepth 1 -regex \
-		'build/userspace/cargo/thumbv7m-none-eabi/release/$(APP)-[^.]+' \
+	find build/userspace/cargo/thumbv7m-none-eabi/release/deps -maxdepth 1 -regex \
+		'build/userspace/cargo/thumbv7m-none-eabi/release/deps/$(APP)-[^.]+' \
 		-exec cp '{}' build/userspace/$(APP)/$(BOARD)/app ';'
 
 # Due to b/139156455, we want to detect the case where an application's size is

--- a/userspace/flash_test/Cargo.toml
+++ b/userspace/flash_test/Cargo.toml
@@ -22,7 +22,7 @@ publish = false
 [dependencies]
 h1 = { features = ["test"], path = "../../kernel/h1" }
 kernel = { path = "../../third_party/tock/kernel" }
-libtock = { path = "../../third_party/libtock-rs" }
 
 [dev-dependencies]
+libtock = { path = "../../third_party/libtock-rs" }
 test = { path = "../test_harness" }

--- a/userspace/flash_test/src/driver.rs
+++ b/userspace/flash_test/src/driver.rs
@@ -13,15 +13,15 @@
 // limitations under the License.
 
 use h1::hil::flash::{Flash,Hardware};
-use kernel::hil::time::Alarm;
+use kernel::hil::time::{Alarm,Ticks};
 use kernel::ReturnCode;
 use test::require;
 
-// These are in counts of a 16 MHz clock.
+// These are in counts of a 256 kHz clock.
 #[cfg(test)]
-const ERASE_TIME: u32 = 53653;
+const ERASE_TIME: u32 = 859;
 #[cfg(test)]
-const WRITE_WORD_TIME: u32 = 840;
+const WRITE_WORD_TIME: u32 = 14;
 
 static mut WRITE_BUF: [u32; 1] = [0; 1];
 
@@ -75,23 +75,23 @@ fn erase() -> bool {
     let driver = unsafe { h1::hil::flash::FlashImpl::new(&alarm, &hw) };
     driver.set_client(&client);
     require!(driver.erase(2) == kernel::ReturnCode::SUCCESS);
-    require!(alarm.get_alarm() == alarm.now() + ERASE_TIME);
+    require!(alarm.get_alarm() == alarm.now().wrapping_add(ERASE_TIME.into()));
     require!(client.state() == None);
     require!(hw.is_programming() == true);
 
     // Indicate an error, let the driver retry.
-    alarm.set_time(ERASE_TIME);
+    alarm.set_time(ERASE_TIME.into());
     hw.inject_result(0b100);
-    driver.fired();
-    require!(alarm.get_alarm() == 2 * ERASE_TIME);
+    driver.alarm();
+    require!(alarm.get_alarm() == (2 * ERASE_TIME).into());
     require!(hw.is_programming() == true);
     require!(client.state() == None);
 
     // Let the operation finish successfully.
-    alarm.set_time(2 * ERASE_TIME);
+    alarm.set_time((2 * ERASE_TIME).into());
     hw.finish_operation();
-    driver.fired();
-    require!(alarm.get_alarm() == 0);
+    driver.alarm();
+    require!(alarm.get_alarm() == 0.into());
     require!(hw.is_programming() == false);
     require!(hw.read(1300) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
     require!(client.state() == Some(MockClientState::EraseDone(kernel::ReturnCode::SUCCESS)));
@@ -109,24 +109,24 @@ fn erase_max_retries() -> bool {
     let driver = unsafe { h1::hil::flash::FlashImpl::new(&alarm, &hw) };
     driver.set_client(&client);
     require!(driver.erase(2) == kernel::ReturnCode::SUCCESS);
-    require!(alarm.get_alarm() == alarm.now() + ERASE_TIME);
+    require!(alarm.get_alarm() == alarm.now().wrapping_add(ERASE_TIME.into()));
     require!(client.state() == None);
     require!(hw.is_programming() == true);
 
     for i in 1..45 {
         // Indicate an error, let the driver retry.
-        alarm.set_time(ERASE_TIME * i);
+        alarm.set_time((ERASE_TIME * i).into());
         hw.inject_result(0b100);
-        driver.fired();
-        require!(alarm.get_alarm() == alarm.now() + ERASE_TIME);
+        driver.alarm();
+        require!(alarm.get_alarm() == alarm.now().wrapping_add(ERASE_TIME.into()));
         require!(hw.is_programming() == true);
         require!(client.state() == None);
     }
 
     // Last try.
     hw.inject_result(0b100);
-    driver.fired();
-    require!(alarm.get_alarm() == 0);
+    driver.alarm();
+    require!(alarm.get_alarm() == 0.into());
     require!(hw.is_programming() == false);
     require!(client.state() == Some(MockClientState::EraseDone(kernel::ReturnCode::FAIL)));
     require!(hw.read(1300) == ReturnCode::SuccessWithValue { value: 0xFFFFFFFF });
@@ -157,17 +157,17 @@ impl<'a> OperationsTest<'a> {
             WRITE_BUF[0] = val as u32;
             require!(self.driver.write(address, &mut WRITE_BUF) == (kernel::ReturnCode::SUCCESS, None));
         }
-        require!(self.alarm.get_alarm() == self.alarm.now() + WRITE_WORD_TIME);
+        require!(self.alarm.get_alarm() == self.alarm.now().wrapping_add(WRITE_WORD_TIME.into()));
         require!(self.client.state() == None);
         require!(self.hw.is_programming() == true);
-        self.alarm.set_time(WRITE_WORD_TIME);
+        self.alarm.set_time(WRITE_WORD_TIME.into());
         self.hw.inject_result(0);
-        self.driver.fired();
+        self.driver.alarm();
         require!(self.hw.is_programming() == true);
         require!(self.client.state() == None);
         self.hw.finish_operation();
-        self.driver.fired();
-        require!(self.alarm.get_alarm() == 0);
+        self.driver.alarm();
+        require!(self.alarm.get_alarm() == 0.into());
         require!(self.hw.is_programming() == false);
         require!(self.client.state() == Some(MockClientState::WriteDone(kernel::ReturnCode::SUCCESS)));
 
@@ -178,12 +178,12 @@ impl<'a> OperationsTest<'a> {
         use kernel::hil::time::{AlarmClient,Time};
 
         require!(self.driver.erase(page) == kernel::ReturnCode::SUCCESS);
-        require!(self.alarm.get_alarm() == self.alarm.now() + ERASE_TIME);
+        require!(self.alarm.get_alarm() == self.alarm.now().wrapping_add(ERASE_TIME.into()));
         require!(self.hw.is_programming() == true);
-        self.alarm.set_time(WRITE_WORD_TIME + ERASE_TIME);
+        self.alarm.set_time((WRITE_WORD_TIME + ERASE_TIME).into());
         self.hw.finish_operation();
-        self.driver.fired();
-        require!(self.alarm.get_alarm() == 0);
+        self.driver.alarm();
+        require!(self.alarm.get_alarm() == 0.into());
         require!(self.hw.is_programming() == false);
         require!(self.client.state() == Some(MockClientState::EraseDone(kernel::ReturnCode::SUCCESS)));
 
@@ -266,28 +266,28 @@ fn successful_program() -> bool {
         WRITE_BUF[0] = 0xFFFFABCD;
         require!(driver.write(1300, &mut WRITE_BUF) == (kernel::ReturnCode::SUCCESS, None));
     }
-    require!(alarm.get_alarm() == alarm.now() + WRITE_WORD_TIME);
+    require!(alarm.get_alarm() == alarm.now().wrapping_add(WRITE_WORD_TIME.into()));
     require!(client.state() == None);
     require!(hw.is_programming() == true);
 
     // Indicate an error, let the driver retry.
-    alarm.set_time(WRITE_WORD_TIME);
+    alarm.set_time(WRITE_WORD_TIME.into());
     hw.inject_result(0b100);
-    driver.fired();
-    require!(alarm.get_alarm() == 2 * WRITE_WORD_TIME);
+    driver.alarm();
+    require!(alarm.get_alarm() == (2 * WRITE_WORD_TIME).into());
     require!(hw.is_programming() == true);
     require!(client.state() == None);
 
     // Let the operation finish successfully (including the final pulse).
-    alarm.set_time(2 * WRITE_WORD_TIME);
+    alarm.set_time((2 * WRITE_WORD_TIME).into());
     hw.inject_result(0);
-    driver.fired();
-    require!(alarm.get_alarm() == 3 * WRITE_WORD_TIME);
+    driver.alarm();
+    require!(alarm.get_alarm() == (3 * WRITE_WORD_TIME).into());
     require!(hw.is_programming() == true);
     require!(client.state() == None);
     hw.finish_operation();
-    driver.fired();
-    require!(alarm.get_alarm() == 0);
+    driver.alarm();
+    require!(alarm.get_alarm() == 0.into());
     require!(hw.is_programming() == false);
     require!(client.state() == Some(MockClientState::WriteDone(kernel::ReturnCode::SUCCESS)));
     require!(driver.read(1300) == ReturnCode::SuccessWithValue { value: 0xFFFFABCD });
@@ -312,14 +312,14 @@ fn timeout() -> bool {
         WRITE_BUF[0] = 0xFFFFABCD;
         require!(driver.write(1300, &mut WRITE_BUF) == (kernel::ReturnCode::SUCCESS, None));
     }
-    require!(alarm.get_alarm() == alarm.now() + WRITE_WORD_TIME);
+    require!(alarm.get_alarm() == alarm.now().wrapping_add(WRITE_WORD_TIME.into()));
     require!(client.state() == None);
     require!(hw.is_programming() == true);
 
     // Indicate a timeout.
-    alarm.set_time(WRITE_WORD_TIME);
-    driver.fired();
-    require!(alarm.get_alarm() == 0);
+    alarm.set_time(WRITE_WORD_TIME.into());
+    driver.alarm();
+    require!(alarm.get_alarm() == 0.into());
     require!(client.state() == Some(MockClientState::WriteDone(kernel::ReturnCode::FAIL)));
 
     true
@@ -338,24 +338,24 @@ fn write_max_retries() -> bool {
         WRITE_BUF[0] = 0xFFFFABCD;
         require!(driver.write(1300, &mut WRITE_BUF) == (kernel::ReturnCode::SUCCESS, None));
     }
-    require!(alarm.get_alarm() == alarm.now() + WRITE_WORD_TIME);
+    require!(alarm.get_alarm() == alarm.now().wrapping_add(WRITE_WORD_TIME.into()));
     require!(client.state() == None);
     require!(hw.is_programming() == true);
 
     for _ in 1..8 {
         // Indicate an error, let the driver retry.
-        alarm.set_time(100 * WRITE_WORD_TIME);
+        alarm.set_time((100 * WRITE_WORD_TIME).into());
         hw.inject_result(0b100);
-        driver.fired();
-        require!(alarm.get_alarm() == alarm.now() + WRITE_WORD_TIME);
+        driver.alarm();
+        require!(alarm.get_alarm() == alarm.now().wrapping_add(WRITE_WORD_TIME.into()));
         require!(hw.is_programming() == true);
         require!(client.state() == None);
     }
 
     // Last try.
     hw.inject_result(0b100);
-    driver.fired();
-    require!(alarm.get_alarm() == 0);
+    driver.alarm();
+    require!(alarm.get_alarm() == 0.into());
     require!(hw.is_programming() == false);
     require!(client.state() == Some(MockClientState::WriteDone(kernel::ReturnCode::FAIL)));
 

--- a/userspace/layout.ld
+++ b/userspace/layout.ld
@@ -22,6 +22,5 @@ MEMORY {
 }
 
 MPU_MIN_ALIGN = 8K;
-STACK_SIZE = 2048;
 
-INCLUDE ../third_party/libtock-rs/layout.ld
+INCLUDE ../third_party/libtock-rs/layout_generic.ld

--- a/userspace/layout_a.ld
+++ b/userspace/layout_a.ld
@@ -25,6 +25,5 @@ MEMORY {
 }
 
 MPU_MIN_ALIGN = 8K;
-STACK_SIZE = 2048;
 
-INCLUDE ../third_party/libtock-rs/layout.ld
+INCLUDE ../third_party/libtock-rs/layout_generic.ld

--- a/userspace/layout_b.ld
+++ b/userspace/layout_b.ld
@@ -25,6 +25,5 @@ MEMORY {
 }
 
 MPU_MIN_ALIGN = 8K;
-STACK_SIZE = 2048;
 
-INCLUDE ../third_party/libtock-rs/layout.ld
+INCLUDE ../third_party/libtock-rs/layout_generic.ld

--- a/userspace/low_level_debug/Cargo.toml
+++ b/userspace/low_level_debug/Cargo.toml
@@ -19,9 +19,6 @@ authors = ["jrvanwhy <jrvanwhy@google.com>"]
 edition = "2018"
 publish = false
 
-[dependencies.core]
-package = "async-support"
-path = "../../third_party/libtock-rs/async-support"
-
 [dependencies]
 libtock = { path = "../../third_party/libtock-rs" }
+libtock_core = { path = "../../third_party/libtock-rs/core" }

--- a/userspace/otpilot/Cargo.toml
+++ b/userspace/otpilot/Cargo.toml
@@ -21,13 +21,10 @@ authors = ["Oskar Senft <osk@google.com>"]
 edition = "2018"
 publish = false
 
-[dependencies.core]
-package = "async-support"
-path = "../../third_party/libtock-rs/async-support"
-
 [dependencies]
 byteorder = { version = "1.3.4", default_features = false }
 libtock = { path = "../../third_party/libtock-rs" }
+libtock_core = { path = "../../third_party/libtock-rs/core" }
 manticore = { path = "../../third_party/manticore", default_features = false }
 spiutils = { path = "../../shared-lib/spiutils", default_features = false }
 ux = { path = "../../third_party/ux-0.1.3", default_features = false }

--- a/userspace/otpilot/src/console_processor.rs
+++ b/userspace/otpilot/src/console_processor.rs
@@ -20,9 +20,7 @@ use crate::globalsec;
 use crate::gpio_processor::GpioProcessor;
 use crate::reset;
 
-use core::fmt::Write;
-
-use libtock::console::Console;
+use libtock::println;
 use libtock::result::TockResult;
 
 pub struct ConsoleProcessor<'a> {
@@ -37,22 +35,20 @@ impl<'a> ConsoleProcessor<'a> {
     }
 
     fn print_help(&self) -> TockResult<()> {
-        let mut console = Console::new();
 
-        writeln!(console, "Available commands:")?;
-        writeln!(console, "? : This help screen.")?;
-        writeln!(console, "1 : Assert BMC_CPU_RST.")?;
-        writeln!(console, "! : Deassert BMC_CPU_RST.")?;
-        writeln!(console, "2 : Assert BMC_SRST.")?;
-        writeln!(console, "@ : Deassert BMC_SRST.")?;
-        writeln!(console, "i : Read firmware info.")?;
-        writeln!(console, "R : Reset chip.")?;
+        println!("Available commands:");
+        println!("? : This help screen.");
+        println!("1 : Assert BMC_CPU_RST.");
+        println!("! : Deassert BMC_CPU_RST.");
+        println!("2 : Assert BMC_SRST.");
+        println!("@ : Deassert BMC_SRST.");
+        println!("i : Read firmware info.");
+        println!("R : Reset chip.");
 
         Ok(())
     }
 
     pub fn process_input(&self) -> TockResult<()> {
-        let mut console = Console::new();
 
         let data = console_reader::get().get_data();
         if data.len() < 1 {
@@ -62,29 +58,29 @@ impl<'a> ConsoleProcessor<'a> {
         match data[0] as char {
             '?' => self.print_help()?,
             '1' => {
-                writeln!(console, "Asserting BMC_CPU_RST")?;
+                println!("Asserting BMC_CPU_RST");
                 self.gpio_processor.set_bmc_cpu_rst(true)?;
             },
             '!' => {
-                writeln!(console, "Deasserting BMC_CPU_RST")?;
+                println!("Deasserting BMC_CPU_RST");
                 self.gpio_processor.set_bmc_cpu_rst(false)?;
             },
             '2' => {
-                writeln!(console, "Asserting BMC_SRST")?;
+                println!("Asserting BMC_SRST");
                 self.gpio_processor.set_bmc_srst(true)?;
             },
             '@' => {
-                writeln!(console, "Deasserting BMC_SRST")?;
+                println!("Deasserting BMC_SRST");
                 self.gpio_processor.set_bmc_srst(false)?;
             },
             'i' => {
-                writeln!(console, "active RO: {:?}, {:?}", globalsec::get().get_active_ro(), firmware_controller::get_build_info(globalsec::get().get_active_ro())?)?;
-                writeln!(console, "active RW: {:?}, {:?}", globalsec::get().get_active_rw(), firmware_controller::get_build_info(globalsec::get().get_active_rw())?)?;
-                writeln!(console, "inactive RO: {:?}, {:?}", globalsec::get().get_inactive_ro(), firmware_controller::get_build_info(globalsec::get().get_inactive_ro())?)?;
-                writeln!(console, "inactive RW: {:?}, {:?}", globalsec::get().get_inactive_rw(), firmware_controller::get_build_info(globalsec::get().get_inactive_rw())?)?;
+                println!("active RO: {:?}, {:?}", globalsec::get().get_active_ro(), firmware_controller::get_build_info(globalsec::get().get_active_ro())?);
+                println!("active RW: {:?}, {:?}", globalsec::get().get_active_rw(), firmware_controller::get_build_info(globalsec::get().get_active_rw())?);
+                println!("inactive RO: {:?}, {:?}", globalsec::get().get_inactive_ro(), firmware_controller::get_build_info(globalsec::get().get_inactive_ro())?);
+                println!("inactive RW: {:?}, {:?}", globalsec::get().get_inactive_rw(), firmware_controller::get_build_info(globalsec::get().get_inactive_rw())?);
             },
             'R' => {
-                writeln!(console, "resetting ...")?;
+                println!("resetting ...");
                 reset::get().reset()?;
             }
             _ => (),

--- a/userspace/otpilot/src/firmware_controller.rs
+++ b/userspace/otpilot/src/firmware_controller.rs
@@ -16,9 +16,8 @@
 
 use crate::flash;
 
-use core::fmt::Write;
 
-use libtock::console::Console;
+use libtock::println;
 use libtock::result::TockError;
 use libtock::result::TockResult;
 
@@ -81,8 +80,7 @@ impl FirmwareController {
         let flash_op_result = flash::get().get_operation_result();
         flash::get().clear_operation();
         if flash_op_result < 0 {
-            let mut console = Console::new();
-            writeln!(console, "flash operation error {}", flash_op_result)?;
+            println!("flash operation error {}", flash_op_result);
             return Err(FirmwareControllerError::FlashOperationFailed);
         }
 
@@ -129,8 +127,7 @@ impl FirmwareController {
         unsafe {
             // TODO(osk): We need the unsafe block since we're accessing WRITE_BUF as &mut.
             if flash::get().write(self.get_write_flash_offset(), &mut WRITE_BUF, self.write_length).is_err() {
-                let mut console = Console::new();
-                writeln!(console, "flash write failed")?;
+                println!("flash write failed");
                 return Err(FirmwareControllerError::FlashWriteError);
             }
         }
@@ -142,8 +139,7 @@ impl FirmwareController {
         // Read data back
         let mut read_buf = [0u8; flash::MAX_BUFFER_LENGTH];
         if flash::get().read(self.get_write_flash_offset(), &mut read_buf, self.write_length).is_err() {
-            let mut console = Console::new();
-            writeln!(console, "flash read failed")?;
+            println!("flash read failed");
             return Err(FirmwareControllerError::FlashReadError);
         }
 
@@ -154,8 +150,7 @@ impl FirmwareController {
                 write_val = WRITE_BUF[idx];
             }
             if read_buf[idx] != write_val {
-                let mut console = Console::new();
-                writeln!(console, "flash compare failed")?;
+                println!("flash compare failed");
                 return Ok(false);
             }
         }

--- a/userspace/otpilot/src/gpio.rs
+++ b/userspace/otpilot/src/gpio.rs
@@ -15,24 +15,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use core::cell::Cell;
-use core::convert::TryFrom;
+use core::cmp::min;
 
-use libtock::gpio::GpioPinUnitialized;
-use libtock::gpio::GpioPinRead;
-use libtock::gpio::GpioPinWrite;
-use libtock::gpio::{IrqMode, InputMode};
+use libtock::println;
 use libtock::result::TockError;
 use libtock::result::TockResult;
+use libtock::syscalls;
 
-/// GPIO pins.
-#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
-#[allow(non_camel_case_types)]
-pub enum GpioPin {
-    BMC_SRST_N = 0,
-    BMC_CPU_RST_N = 1,
-    SYS_RSTMON_N = 2,
-    BMC_RSTMON_N = 3,
-}
+const MAX_GPIOS: usize = 4;
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 #[allow(dead_code)]
@@ -41,189 +31,273 @@ pub enum GpioValue {
     High,
 }
 
-pub trait GpioControl {
-    /// Check if there are any events to be consumed.
-    fn have_events(&self) -> bool;
-
-    /// Consume one event on the specified pin.
-    /// Returns true if there was an event to be consumed.
-    fn consume_event(&self, pin: GpioPin) -> bool;
-
-    /// Clear all events on the specified pin.
-    /// Returns true if there was an event.
-    fn clear_event(&self, pin: GpioPin) -> bool;
-
-    /// Set GpioPin value.
-    fn set(&self, pin: GpioPin, val: GpioValue) -> TockResult<()>;
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[allow(dead_code)]
+pub enum FloatingState {
+    PullNone = 0,
+    PullUp = 1,
+    PullDown = 2,
 }
 
-// Get the static GpioControl object.
-pub fn get() -> &'static dyn GpioControl {
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[allow(dead_code)]
+pub enum InterruptEdge {
+    EitherEdge = 0,
+    RisingEdge = 1,
+    FallingEdge = 2,
+}
+
+pub trait Gpio {
+    /// Get the number of available GPIOs.
+    fn get_num_gpios(&self) -> usize;
+
+    /// Enable the specified GPIO for output.
+    fn enable_output(&self, gpio_num: usize) -> TockResult<()>;
+
+    /// Enable the specified GPIO for input.
+    fn enable_input(&self, gpio_num: usize, floating_state: FloatingState) -> TockResult<()>;
+
+    /// Disable the specified GPIO.
+    fn disable(&self, gpio_num: usize) -> TockResult<()>;
+
+    /// Write a value to the specified GPIO.
+    fn write(&self, gpio_num: usize, val: GpioValue) -> TockResult<()>;
+
+    /// Toggle the specified GPIO.
+    fn toggle(&self, gpio_num: usize) -> TockResult<()>;
+
+    /// Read the current value off the specified GPIO.
+    fn read(&self, gpio_num: usize) -> TockResult<GpioValue>;
+
+    /// Enable events to be received on the specified GPIO.
+    fn enable_events(&self, gpio_num: usize, edge: InterruptEdge) -> TockResult<()>;
+
+    /// Disable events to be received on the specified GPIO.
+    fn disable_events(&self, gpio_num: usize, edge: InterruptEdge) -> TockResult<()>;
+
+    /// Check if there are events to be consumed on the specified GPIO.
+    fn has_event(&self, gpio_num: usize) -> bool;
+
+    /// Consume one event on the specified GPIO.
+    /// Returns true if there was an event to be consumed.
+    fn consume_event(&self, gpio_num: usize) -> bool;
+
+    /// Clear all events on the specified GPIO.
+    /// Returns true if there was an event.
+    fn clear_event(&self, gpio_num: usize) -> bool;
+}
+
+// Get the static Gpio object.
+pub fn get() -> &'static dyn Gpio {
     get_impl()
 }
 
-/// Error for invalid GpioPin conversion.
-pub struct InvalidGpioPin;
+const DRIVER_NUMBER: usize = 0x00004;
 
-impl TryFrom<usize> for GpioPin {
-    type Error = InvalidGpioPin;
+mod command_nr {
+    pub const COUNT: usize = 0;
+    pub const ENABLE_OUTPUT: usize = 1;
+    pub const SET: usize = 2;
+    pub const CLEAR: usize = 3;
+    pub const TOGGLE: usize = 4;
+    pub const ENABLE_INPUT: usize = 5;
+    pub const READ: usize = 6;
+    pub const INTERRUPT_ENABLE: usize = 7;
+    pub const INTERRUPT_DISABLE: usize = 8;
+    pub const DISABLE: usize = 9;
+}
 
-    fn try_from(item: usize) -> Result<GpioPin, Self::Error> {
-        match item {
-            0 => Ok(GpioPin::BMC_SRST_N),
-            1 => Ok(GpioPin::BMC_CPU_RST_N),
-            2 => Ok(GpioPin::SYS_RSTMON_N),
-            3 => Ok(GpioPin::BMC_RSTMON_N),
-            _ => Err(InvalidGpioPin),
-        }
+mod subscribe_nr {
+    pub const SUBSCRIBE_CALLBACK: usize = 0;
+}
+
+struct GpioImpl {
+    /// The number of GPIOs
+    num_gpios: usize,
+    events: [Option<Events>; MAX_GPIOS],
+}
+
+static mut GPIO: GpioImpl = {
+    const NONE: Option<Events> = None;
+
+    GpioImpl {
+        num_gpios: 0,
+        events: [NONE; MAX_GPIOS],
     }
-}
-
-impl From<GpioPin> for usize {
-    fn from(item: GpioPin) -> usize {
-        item as usize
-    }
-}
-
-
-struct GpioControlImpl {
-    bmc_srst_n: Option<GpioPinWrite>,
-    bmc_cpu_rst_n: Option<GpioPinWrite>,
-    sys_rstmon_n: Option<GpioPinRead>,
-    bmc_rstmon_n: Option<GpioPinRead>,
-
-    sys_rstmon_n_events: Cell<usize>,
-    bmc_rstmon_n_events: Cell<usize>,
-}
-
-static mut GPIO_CTRL: GpioControlImpl = GpioControlImpl {
-    bmc_srst_n: None,
-    bmc_cpu_rst_n: None,
-    sys_rstmon_n: None,
-    bmc_rstmon_n: None,
-    sys_rstmon_n_events: Cell::new(0),
-    bmc_rstmon_n_events: Cell::new(0),
 };
 
 static mut IS_INITIALIZED: bool = false;
 
-fn get_impl() -> &'static GpioControlImpl {
+fn get_impl() -> &'static GpioImpl {
     unsafe {
         if !IS_INITIALIZED {
-            if GPIO_CTRL.initialize().is_err() {
-                panic!("Could not initialize GPIO Control");
+            if GPIO.initialize().is_err() {
+                panic!("Could not initialize Gpio");
             }
             IS_INITIALIZED = true;
         }
-        &GPIO_CTRL
+        &GPIO
     }
 }
 
-
-/// Adds one event.
-/// If the maximum number of events would be exceeded, do nothing.
-fn add_event(events: &Cell<usize>) {
-    let val = events.get();
-    if val < core::usize::MAX - 1 {
-        events.set(val + 1);
-    }
-}
-
-/// Consumes one event.
-/// Returns the number of events to consume before consuming one.
-fn delete_event(events: &Cell<usize>) -> usize {
-    let val = events.get();
-    if val > core::usize::MIN {
-        events.set(val - 1);
-    }
-    val
-}
-
-/// Clears all events.
-/// Returns the number of events to consume before clearing them.
-fn clear_event(events: &Cell<usize>) -> usize {
-    let val = events.get();
-    events.set(core::usize::MIN);
-    val
-}
-
-/// Checks if we have an event.
-/// Returns true if there's at least one event to be consumed.
-fn have_event(events: &Cell<usize>) -> bool {
-    events.get() > core::usize::MIN
-}
-
-impl GpioControlImpl {
+impl GpioImpl {
     fn initialize(&'static mut self) -> TockResult<()> {
-        self.bmc_srst_n = Some(GpioPinUnitialized::new(GpioPin::BMC_SRST_N as usize).open_for_write()?);
-        self.bmc_cpu_rst_n = Some(GpioPinUnitialized::new(GpioPin::BMC_CPU_RST_N as usize).open_for_write()?);
-        self.sys_rstmon_n = Some(GpioPinUnitialized::new(GpioPin::SYS_RSTMON_N as usize).open_for_read(
-            Some((GpioControlImpl::event_trampoline, IrqMode::RisingEdge)),
-            InputMode::PullNone)?);
-        self.bmc_rstmon_n = Some(GpioPinUnitialized::new(GpioPin::BMC_RSTMON_N as usize).open_for_read(
-            Some((GpioControlImpl::event_trampoline, IrqMode::RisingEdge)),
-            InputMode::PullNone)?);
+        self.num_gpios = syscalls::command(DRIVER_NUMBER, command_nr::COUNT, 0, 0)?;
+
+        if self.num_gpios > self.events.len() {
+            println!("WARNING: The kernel reported {} GPIOs but we only support up to {}.",
+                self.num_gpios, self.events.len())
+        }
+
+        for idx in 0..min(self.num_gpios, self.events.len()) {
+            self.events[idx] = Some(Default::default())
+        }
+
+        syscalls::subscribe_fn(
+            DRIVER_NUMBER,
+            subscribe_nr::SUBSCRIBE_CALLBACK,
+            GpioImpl::callback_trampoline,
+            0)?;
+
         Ok(())
     }
 
-    extern "C" fn event_trampoline(pin_num: usize, pin_state: usize, _: usize, _: usize) {
-        get_impl().event(pin_num, pin_state);
+    extern "C"
+    fn callback_trampoline(arg1: usize, arg2: usize, _arg3: usize, _data: usize) {
+        get_impl().callback(arg1, arg2);
     }
 
-    fn event(&self, pin_num: usize, _pin_state: usize) {
-        let pin = match GpioPin::try_from(pin_num) {
-            Ok(val) => val,
-            Err(_) => return,
-        };
-
-        match pin {
-            GpioPin::SYS_RSTMON_N => add_event(&self.sys_rstmon_n_events),
-            GpioPin::BMC_RSTMON_N => add_event(&self.bmc_rstmon_n_events),
-            _ => (),
-        };
+    fn callback(&self, gpio_num: usize, _pin_state: usize) {
+        self.add_event(gpio_num)
     }
 
-    fn set_value(&self, maybe_pin: &Option<GpioPinWrite>, val: GpioValue) -> TockResult<()> {
-        if let Some(pin) = maybe_pin {
-            match val {
-                GpioValue::Low => pin.set_low(),
-                GpioValue::High => pin.set_high(),
-            }
-        } else {
-            Err(TockError::Format)
+    fn add_event(&self, gpio_num: usize) {
+        if gpio_num >= self.events.len() { return; }
+
+        if let Some(events) = &self.events[gpio_num] {
+            events.add()
         }
     }
 }
 
-impl GpioControl for GpioControlImpl {
-
-    fn have_events(&self) -> bool {
-        have_event(&self.sys_rstmon_n_events) || have_event(&self.bmc_rstmon_n_events)
+impl Gpio for GpioImpl {
+    fn get_num_gpios(&self) -> usize {
+        self.num_gpios
     }
 
-    fn consume_event(&self, pin: GpioPin) -> bool {
-        let val = match pin {
-            GpioPin::SYS_RSTMON_N => delete_event(&self.sys_rstmon_n_events),
-            GpioPin::BMC_RSTMON_N => delete_event(&self.bmc_rstmon_n_events),
-            _ => 0,
+    fn enable_output(&self, gpio_num: usize) -> TockResult<()> {
+        syscalls::command(DRIVER_NUMBER, command_nr::ENABLE_OUTPUT, gpio_num, 0)?;
+
+        Ok(())
+    }
+    fn enable_input(&self, gpio_num: usize, floating_state: FloatingState) -> TockResult<()> {
+        syscalls::command(DRIVER_NUMBER, command_nr::ENABLE_INPUT, gpio_num, floating_state as usize)?;
+
+        Ok(())
+    }
+    fn disable(&self, gpio_num: usize) -> TockResult<()> {
+        syscalls::command(DRIVER_NUMBER, command_nr::DISABLE, gpio_num, 0)?;
+
+        Ok(())
+    }
+    fn write(&self, gpio_num: usize, val: GpioValue) -> TockResult<()> {
+        match val {
+            GpioValue::High => syscalls::command(DRIVER_NUMBER, command_nr::SET, gpio_num, 0)?,
+            GpioValue::Low => syscalls::command(DRIVER_NUMBER, command_nr::CLEAR, gpio_num, 0)?,
         };
-        val != 0
-    }
 
-    fn clear_event(&self, pin: GpioPin) -> bool {
-        let val = match pin {
-            GpioPin::SYS_RSTMON_N => clear_event(&self.sys_rstmon_n_events),
-            GpioPin::BMC_RSTMON_N => clear_event(&self.bmc_rstmon_n_events),
-            _ => 0,
-        };
-        val != 0
+        Ok(())
     }
+    fn toggle(&self, gpio_num: usize) -> TockResult<()> {
+        syscalls::command(DRIVER_NUMBER, command_nr::TOGGLE, gpio_num, 0)?;
 
-    fn set(&self, pin: GpioPin, val: GpioValue) -> TockResult<()> {
-        match pin {
-            GpioPin::BMC_SRST_N => self.set_value(&self.bmc_srst_n, val),
-            GpioPin::BMC_CPU_RST_N => self.set_value(&self.bmc_cpu_rst_n, val),
-            _ => Ok(()),
+        Ok(())
+    }
+    fn read(&self, gpio_num: usize) -> TockResult<GpioValue> {
+        match syscalls::command(DRIVER_NUMBER, command_nr::READ, gpio_num, 0)? {
+            0 => Ok(GpioValue::Low),
+            1 => Ok(GpioValue::High),
+            _ => Err(TockError::Format),
         }
+    }
+    fn enable_events(&self, gpio_num: usize, edge: InterruptEdge) -> TockResult<()> {
+        syscalls::command(DRIVER_NUMBER, command_nr::INTERRUPT_ENABLE, gpio_num, edge as usize)?;
+
+        Ok(())
+    }
+    fn disable_events(&self, gpio_num: usize, edge: InterruptEdge) -> TockResult<()> {
+        syscalls::command(DRIVER_NUMBER, command_nr::INTERRUPT_DISABLE, gpio_num, edge as usize)?;
+
+        Ok(())
+    }
+
+    fn has_event(&self, gpio_num: usize) -> bool {
+        if gpio_num >= self.events.len() { return false; }
+
+        if let Some(events) = &self.events[gpio_num] {
+            events.has_any()
+        } else {
+            false
+        }
+    }
+
+    fn consume_event(&self, gpio_num: usize) -> bool {
+        if gpio_num >= self.events.len() { return false; }
+
+        if let Some(events) = &self.events[gpio_num] {
+            events.consume() > 0
+        } else {
+            false
+        }
+    }
+
+    fn clear_event(&self, gpio_num: usize) -> bool {
+        if gpio_num >= self.events.len() { return false; }
+
+        if let Some(events) = &self.events[gpio_num] {
+            events.clear() > 0
+        } else {
+            false
+        }
+    }
+}
+
+#[derive(Default)]
+struct Events {
+    count: Cell<usize>,
+}
+
+impl Events {
+    /// Adds one event.
+    /// If the maximum number of events would be exceeded, do nothing.
+    fn add(&self) {
+        let val = self.count.get();
+        if val < core::usize::MAX - 1 {
+            self.count.set(val + 1);
+        }
+    }
+
+    /// Consumes one event.
+    /// Returns the number of events to consume before consuming one.
+    fn consume(&self) -> usize {
+        let val = self.count.get();
+        if val > core::usize::MIN {
+            self.count.set(val - 1);
+        }
+        val
+    }
+
+    /// Clears all events.
+    /// Returns the number of events to consume before clearing them.
+    fn clear(&self) -> usize {
+        let val = self.count.get();
+        self.count.set(core::usize::MIN);
+        val
+    }
+
+    /// Checks if we have an event.
+    /// Returns true if there's at least one event to be consumed.
+    fn has_any(&self) -> bool {
+        self.count.get() > core::usize::MIN
     }
 }

--- a/userspace/otpilot/src/gpio_control.rs
+++ b/userspace/otpilot/src/gpio_control.rs
@@ -1,0 +1,134 @@
+// Copyright 2021 lowRISC contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::gpio;
+use crate::gpio::FloatingState;
+use crate::gpio::GpioValue;
+use crate::gpio::InterruptEdge;
+
+use core::convert::TryFrom;
+
+use libtock::result::TockResult;
+
+/// GPIO pins and mapping to kernel number.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+#[allow(non_camel_case_types)]
+pub enum GpioPin {
+    BMC_SRST_N = 0,
+    BMC_CPU_RST_N = 1,
+    SYS_RSTMON_N = 2,
+    BMC_RSTMON_N = 3,
+}
+
+pub trait GpioControl {
+    /// Check if there are any events to be consumed.
+    fn have_events(&self) -> bool;
+
+    /// Consume one event on the specified pin.
+    /// Returns true if there was an event to be consumed.
+    fn consume_event(&self, pin: GpioPin) -> bool;
+
+    /// Clear all events on the specified pin.
+    /// Returns true if there was an event.
+    fn clear_event(&self, pin: GpioPin) -> bool;
+
+    /// Set GpioPin value.
+    fn set(&self, pin: GpioPin, val: GpioValue) -> TockResult<()>;
+}
+
+// Get the static GpioControl object.
+pub fn get() -> &'static dyn GpioControl {
+    get_impl()
+}
+
+/// Error for invalid GpioPin conversion.
+pub struct InvalidGpioPin;
+
+impl TryFrom<usize> for GpioPin {
+    type Error = InvalidGpioPin;
+
+    fn try_from(item: usize) -> Result<GpioPin, Self::Error> {
+        match item {
+            0 => Ok(GpioPin::BMC_SRST_N),
+            1 => Ok(GpioPin::BMC_CPU_RST_N),
+            2 => Ok(GpioPin::SYS_RSTMON_N),
+            3 => Ok(GpioPin::BMC_RSTMON_N),
+            _ => Err(InvalidGpioPin),
+        }
+    }
+}
+
+impl From<GpioPin> for usize {
+    fn from(item: GpioPin) -> usize {
+        item as usize
+    }
+}
+
+
+struct GpioControlImpl {
+}
+
+static mut GPIO_CTRL: GpioControlImpl = GpioControlImpl {
+};
+
+static mut IS_INITIALIZED: bool = false;
+
+fn get_impl() -> &'static GpioControlImpl {
+    unsafe {
+        if !IS_INITIALIZED {
+            if GPIO_CTRL.initialize().is_err() {
+                panic!("Could not initialize GPIO Control");
+            }
+            IS_INITIALIZED = true;
+        }
+        &GPIO_CTRL
+    }
+}
+
+
+impl GpioControlImpl {
+    fn initialize(&'static mut self) -> TockResult<()> {
+        gpio::get().enable_output(GpioPin::BMC_SRST_N as usize)?;
+        gpio::get().enable_output(GpioPin::BMC_CPU_RST_N as usize)?;
+        gpio::get().enable_input(GpioPin::SYS_RSTMON_N as usize, FloatingState::PullNone)?;
+        gpio::get().enable_events(GpioPin::SYS_RSTMON_N as usize, InterruptEdge::RisingEdge)?;
+        gpio::get().enable_input(GpioPin::BMC_RSTMON_N as usize, FloatingState::PullNone)?;
+        gpio::get().enable_events(GpioPin::BMC_RSTMON_N as usize, InterruptEdge::RisingEdge)?;
+        Ok(())
+    }
+}
+
+impl GpioControl for GpioControlImpl {
+
+    fn have_events(&self) -> bool {
+        gpio::get().has_event(GpioPin::SYS_RSTMON_N as usize) ||
+            gpio::get().has_event(GpioPin::BMC_RSTMON_N as usize)
+    }
+
+    fn consume_event(&self, pin: GpioPin) -> bool {
+        gpio::get().consume_event(pin as usize)
+    }
+
+    fn clear_event(&self, pin: GpioPin) -> bool {
+        gpio::get().clear_event(pin as usize)
+    }
+
+    fn set(&self, pin: GpioPin, val: GpioValue) -> TockResult<()> {
+        gpio::get().write(pin as usize, val)
+    }
+}
+
+

--- a/userspace/otpilot/src/spi_host_helper.rs
+++ b/userspace/otpilot/src/spi_host_helper.rs
@@ -16,12 +16,13 @@
 
 use crate::spi_host;
 
-use core::fmt::Write;
 
-use libtock::console::Console;
+use libtock::println;
 use libtock::result::TockResult;
 
 pub struct SpiHostHelper;
+
+static mut TXBUFFER: [u8; spi_host::MAX_READ_BUFFER_LENGTH] = [0xff; spi_host::MAX_READ_BUFFER_LENGTH];
 
 impl SpiHostHelper {
     pub fn enter_4b(&self) -> TockResult<()> {
@@ -36,25 +37,30 @@ impl SpiHostHelper {
         Ok(())
     }
 
-    fn create_tx_buf(&self, cmd: u8, addr: u32) -> ([u8; spi_host::MAX_READ_BUFFER_LENGTH], usize) {
-        let mut tx = [0xff; spi_host::MAX_READ_BUFFER_LENGTH];
-        tx[0] = cmd;
-        tx[1..5].copy_from_slice(&addr.to_be_bytes());
-        (tx, 5)
+    fn create_tx_buf(&self, cmd: u8, addr: u32) -> usize {
+        unsafe {
+            TXBUFFER[0] = cmd;
+            TXBUFFER[1..5].copy_from_slice(&addr.to_be_bytes());
+            for idx in 5..TXBUFFER.len() {
+                TXBUFFER[idx] = 0xff;
+            }
+            5
+        }
     }
 
     pub fn read_data<'a>(&self, addr: u32, rx_len: usize) -> TockResult<&'static[u8]> {
-        let (mut tx, tx_len) = self.create_tx_buf(0x03, addr);
-        spi_host::get().read_write_bytes(&mut tx, tx_len + rx_len)?;
+        let tx_len = self.create_tx_buf(0x03, addr);
+        unsafe {
+            spi_host::get().read_write_bytes(&mut TXBUFFER, tx_len + rx_len)?;
+        }
         spi_host::get().wait_read_write_done();
         Ok(&spi_host::get().get_read_buffer()[tx_len..])
     }
 
     pub fn read_and_print_data(&self, addr: u32) -> TockResult<()> {
-        let mut console = Console::new();
 
         let rx_buf = self.read_data(addr, 8)?;
-        writeln!(console, "Host: Result: {:02x?}", rx_buf)?;
+        println!("Host: Result: {:02x?}", rx_buf);
         Ok(())
     }
 }

--- a/userspace/otpilot/src/spi_processor.rs
+++ b/userspace/otpilot/src/spi_processor.rs
@@ -26,9 +26,8 @@ use crate::spi_device;
 
 use core::cmp::min;
 use core::convert::TryFrom;
-use core::fmt::Write;
 
-use libtock::console::Console;
+use libtock::println;
 use libtock::result::TockError;
 
 use manticore::io::Cursor as ManticoreCursor;
@@ -244,8 +243,7 @@ impl<'a> SpiProcessor<'a> {
                 self.send_firmware_response(response)
             },
             Err(why) => {
-                let mut console = Console::new();
-                let _ = writeln!(console, "update_prepare failed: {:?}", why);
+                println!("update_prepare failed: {:?}", why);
                 let response = firmware::UpdatePrepareResponse {
                     segment_and_location: req.segment_and_location,
                     max_chunk_length: 0,
@@ -508,19 +506,18 @@ impl<'a> SpiProcessor<'a> {
     }
 
     pub fn process_spi_packet(&mut self, mut rx_buf: &[u8]) -> SpiProcessorResult<()> {
-        let mut console = Console::new();
         match spi_device::get().get_address_mode() {
             AddressMode::ThreeByte => {
                 let header = spi_flash::Header::<ux::u24>::from_wire(&mut rx_buf)?;
                 if self.print_flash_headers {
-                    writeln!(console, "Device: flash header (3B): {:?}", header)?;
+                    println!("Device: flash header (3B): {:?}", header);
                 }
                 self.process_spi_header(&header, rx_buf)
             }
             AddressMode::FourByte => {
                 let header = spi_flash::Header::<u32>::from_wire(&mut rx_buf)?;
                 if self.print_flash_headers {
-                    writeln!(console, "Device: flash header (4B): {:?}", header)?;
+                    println!("Device: flash header (4B): {:?}", header);
                 }
                 self.process_spi_header(&header, rx_buf)
             }

--- a/userspace/test_harness/Cargo.toml
+++ b/userspace/test_harness/Cargo.toml
@@ -21,3 +21,4 @@ publish = false
 
 [dependencies]
 libtock = { path = "../../third_party/libtock-rs" }
+libtock_core = { path = "../../third_party/libtock-rs/core" }

--- a/userspace/test_harness/src/assertions.rs
+++ b/userspace/test_harness/src/assertions.rs
@@ -16,10 +16,7 @@
 /// but returns false rather than panicking on failure.
 
 pub fn print_failure(expr: &str) {
-    let mut console = libtock::console::Console::new();
-    let _ = console.write("FAILED: ");
-    let _ = console.write(expr);
-    let _ = console.write("\n");
+    libtock::println!("FAILED: {}", expr);
 }
 
 #[macro_export]
@@ -39,9 +36,7 @@ macro_rules! require_eq {
         let lhs = $lhs;
         let rhs = $rhs;
         if lhs != rhs {
-            use core::fmt::Write;
-            let _ = writeln!(libtock::console::Console::new(),
-                             "FAILED: {}, {:?} != {:?}", $name, lhs, rhs);
+            libtock::println!("FAILED: {}, {:?} != {:?}", $name, lhs, rhs);
             return false;
         }
     );

--- a/userspace/test_harness/src/lib.rs
+++ b/userspace/test_harness/src/lib.rs
@@ -17,6 +17,7 @@
 // Relies on internal details of rustc, so this may break during toolchain
 // updates.
 
+#![feature(asm)]
 #![no_std]
 
 mod assertions;
@@ -24,3 +25,5 @@ mod compiler_required;
 
 pub use self::assertions::*;
 pub use self::compiler_required::*;
+
+libtock_core::stack_size!{2048}

--- a/userspace/test_harness/src/lib.rs
+++ b/userspace/test_harness/src/lib.rs
@@ -17,7 +17,6 @@
 // Relies on internal details of rustc, so this may break during toolchain
 // updates.
 
-#![feature(asm)]
 #![no_std]
 
 mod assertions;


### PR DESCRIPTION
This change upgrades Tock to just before Tock 2.0 Alpha1 and libtock-rs to current HEAD.

```
----------------------
`make prtest` summary:
----------------------
git rev-parse HEAD
b7b10190df57e4be4974be765b9b033816ca8a67
git status
On branch tock-libtock-rs-upgrade
Your branch is up to date with 'origin/tock-libtock-rs-upgrade'.

nothing to commit, working tree clean
```